### PR TITLE
Use CircleCI to run the build process and push changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,9 @@ jobs:
       only:
         - build-pipeline
     docker:
-      - image: ministryofjustice/cloud-platform-user-guide:1.0
+      # This docker image is created from the Dockerfile in
+      # this repository.
+      - image: ministryofjustice/cloud-platform-user-guide
         environment:
           DOMAIN: user-guide-compiled.cloud-platform.service.justice.gov.uk
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,3 +43,12 @@ jobs:
         # Replace the docs/CNAME file (which gets deleted during the build process)
       - run: echo ${DOMAIN} > docs/CNAME
 
+        # Set git user credentials (otherwise the git push will fail)
+      - run: git config credential.helper cache
+      - run: git config user.email "platforms+githubuser@digital.justice.gov.uk"
+      - run: git config user.name "MoJ Cloud Platform Team Machine User"
+
+        # Add and push the compiled static files
+      - run: git add docs -f
+      - run: git commit -m 'Publish changes via CircleCI'
+      - run: git push origin master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,12 @@ jobs:
             - "b4:43:a7:ce:06:8d:ef:4e:11:71:de:75:65:6c:fa:a2"
 
       - checkout
+
+        # Don't build and push if the latest commit only includes changes to the compiled static files.
+        # This prevents circleci from going into an endless loop, where it pushes changes to docs/ and
+        # then starts a new build because it sees changes to the repo. This script tests for that, and
+        # exits with an error if the build should not proceed.
+      - run: bin/pipeline-should-build.sh
       - run: bundle exec middleman build --build-dir docs
       - run: touch docs/.nojekyll
       - run: echo ${DOMAIN} > docs/CNAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ jobs:
       # this repository.
       - image: ministryofjustice/cloud-platform-user-guide
         environment:
-          DOMAIN: user-guide-compiled.cloud-platform.service.justice.gov.uk
+          # This is the domain on which the user guide is served
+          DOMAIN: user-guide.cloud-platform.service.justice.gov.uk
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,14 @@ jobs:
         # then starts a new build because it sees changes to the repo. This script tests for that, and
         # exits with an error if the build should not proceed.
       - run: bin/pipeline-should-build.sh
+
+        # Build the user guide
       - run: bundle exec middleman build --build-dir docs
+
+        # Replace docs/.nojekyll (which gets deleted during the build process) so github knows we're
+        # not using jekyll. Without this, github will try to process our files, and error.
       - run: touch docs/.nojekyll
+
+        # Replace the docs/CNAME file (which gets deleted during the build process)
       - run: echo ${DOMAIN} > docs/CNAME
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: ministryofjustice/cloud-platform-user-guide:1.0
+        environment:
+          DOMAIN: user-guide-compiled.cloud-platform.service.justice.gov.uk
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: bundle exec middleman build --build-dir docs
+      - run: touch docs/.nojekyll
+      - run: echo $(DOMAIN) > docs/CNAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     branches:
       only:
-        - build-pipeline
+        - master
     docker:
       # This docker image is created from the Dockerfile in
       # this repository.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2
 jobs:
   build:
+    branches:
+      only:
+        - build-pipeline
     docker:
       - image: ministryofjustice/cloud-platform-user-guide:1.0
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,4 +15,4 @@ jobs:
       - checkout
       - run: bundle exec middleman build --build-dir docs
       - run: touch docs/.nojekyll
-      - run: echo $(DOMAIN) > docs/CNAME
+      - run: echo ${DOMAIN} > docs/CNAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,16 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            # this SSH key must be configured in the account of the github user
+            # who will be pushing changes. The corresponding private key must
+            # be added to the project on circleci.com
+            # Currently, this is the 'cloud-platform-moj' github user account.
+            # The GitHub user must be added to the cloud-platform-user-guide
+            # repository as an admin.
+            - "b4:43:a7:ce:06:8d:ef:4e:11:71:de:75:65:6c:fa:a2"
+
       - checkout
       - run: bundle exec middleman build --build-dir docs
       - run: touch docs/.nojekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ FROM ruby:2.6.2-alpine
 RUN apk --update add --virtual build_deps build-base
 
 # Required at runtime by middleman server
-RUN apk add nodejs
+RUN apk add --no-cache nodejs
+
+# Required by the CircleCI build pipeline
+RUN apk add --no-cache git openssh-client
 
 RUN addgroup -g 1000 -S appgroup && \
     adduser -u 1000 -S appuser -G appgroup

--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ make changes to the source files.
 
 ## Making changes
 
-To make changes, edit the appropriate Markdown and ERB files in the
-`source` directory.
+To make changes, create a branch and edit the appropriate Markdown
+and ERB files in the `source` directory.
+
+Every change should be reviewed in a pull request, no matter how
+minor, and we've enabled [branch protection][] to enforce this.
 
 GDS Tech Docs (and therefore this site) uses [kramdown][] for its
 Markdown processing.
@@ -65,8 +68,14 @@ for a basic multipage site.
 
 ## Publishing changes
 
-When you have made your changes, prepare them for publishing by
-running:
+There is a [CircleCI][] build pipeline which will publish your
+changes automatically, when your branch is merged into `master`
+
+So, you should not need to do anything else in order to update
+the user guide website.
+
+In the event that there is a problem with [CircleCI][], you can
+run the build stage manually:
 
 ```bash
 make build
@@ -75,21 +84,7 @@ make build
 Then add, commit and push your changes (including the `docs`
 directory).
 
-Make your changes in a branch, and issue a pull request
-when you want them to be reviewed and published.
-
-We recommend making two separate commits for your changes - the first
-for your changes to the `source` directory, and then a separate commit
-adding the `docs` directory, after you run `make build`. This makes it
-easier for whoever is reviewing your commit, because they can focus on
-your 'source' commit (on the assumption that your 'docs' changes are
-simply a result of running the build process).
-
-Because we're using GitHub Pages, any changes merged into the `master`
-branch will be published automatically. Every change should be reviewed
-in a pull request, no matter how minor, and we've enabled [branch
-protection][] to enforce this.
-
 [branch protection]: https://help.github.com/articles/about-protected-branches/
 [tech-docs-multipage]: https://tdt-documentation.london.cloudapps.digital/multipage.html#repo-folder-structure
+[CircleCI]: https://circleci.com
 

--- a/bin/pipeline-should-build.sh
+++ b/bin/pipeline-should-build.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Our build pipeline should NOT build the project
+# if the only changes are to files in the 'docs'
+# folder (because such changes are only made by
+# the build pipeline, so we would go into an
+# endless loop.
+#
+# However, empty commits probably come from
+# merging PRs, and so those SHOULD be built.
+
+main() {
+  local readonly commit=$(git rev-parse HEAD)
+  local readonly files=$(files_in ${commit})
+
+  if [ -z "${files// }" ]; then
+    # The commit changes no files, so exit with success and continue the build
+    return
+  else
+    # Some files changed by commit. We want to fail out if only docs files were changed
+    for f in ${files}; do
+      if [[ $f =~ ^docs ]]; then
+        true
+      else
+        # Commit changed a file which is not in the docs directory, so exit with success
+        # and continue the build
+        return
+      fi
+    done
+
+    # Only docs files were changed. Exit with a failure code so we do not continue the build
+    exit 1
+  fi
+}
+
+files_in() {
+  local readonly commit=$1
+  git diff-tree --no-commit-id --name-only -r ${commit}
+}
+
+main

--- a/makefile
+++ b/makefile
@@ -15,6 +15,10 @@ server: .built-docker-image
 		-it \
 		$(IMAGE) bundle exec middleman server
 
+# The CircleCI build pipeline does this, so it should never
+# be necessary to run this task. I'm leaving it here for
+# reference, and in case we ever need to push changes
+# manually.
 build: .built-docker-image
 	docker run \
 		-v $$(pwd)/source:/app/source \

--- a/makefile
+++ b/makefile
@@ -1,11 +1,10 @@
 IMAGE := cloud-platform-user-guide
 DOMAIN := user-guide.cloud-platform.service.justice.gov.uk
-VERSION := 1.0
 
 .built-docker-image: Dockerfile Gemfile
 	docker build -t $(IMAGE) .
-	docker tag $(IMAGE) ministryofjustice/$(IMAGE):$(VERSION)
-	docker push ministryofjustice/$(IMAGE):$(VERSION)
+	docker tag $(IMAGE) ministryofjustice/$(IMAGE)
+	docker push ministryofjustice/$(IMAGE)
 	touch .built-docker-image
 
 server: .built-docker-image

--- a/makefile
+++ b/makefile
@@ -1,8 +1,11 @@
 IMAGE := cloud-platform-user-guide
 DOMAIN := user-guide.cloud-platform.service.justice.gov.uk
+VERSION := 1.0
 
 .built-docker-image: Dockerfile Gemfile
 	docker build -t $(IMAGE) .
+	docker tag $(IMAGE) ministryofjustice/$(IMAGE):$(VERSION)
+	docker push ministryofjustice/$(IMAGE):$(VERSION)
 	touch .built-docker-image
 
 server: .built-docker-image


### PR DESCRIPTION
This avoids the need for people to run the build process and commit
changes to the 'compiled' files, as well as their changes to the
source files.

Without a build pipeline, it is hard for multiple people to work
on the user guide at the same time, because there are almost always
merge conflicts in the JSON index files.