### PR TITLE
Use bash for the pipeline checking script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --update add --virtual build_deps build-base
 RUN apk add --no-cache nodejs
 
 # Required by the CircleCI build pipeline
-RUN apk add --no-cache git openssh-client
+RUN apk add --no-cache git openssh-client bash
 
 RUN addgroup -g 1000 -S appgroup && \
     adduser -u 1000 -S appuser -G appgroup

--- a/bin/pipeline-should-build.sh
+++ b/bin/pipeline-should-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Our build pipeline should NOT build the project
 # if the only changes are to files in the 'docs'


### PR DESCRIPTION
The version of sh which alpine installs does not
understand the '=~' operator. So, if that clause
of the script is executed, it fails with:

```
sh: =~: unknown operand
```

Installing bash and using it to execute the shell
script fixes this problem.