### PR TITLE
Make 'docker-push' a separate task

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,15 @@ make build
 Then add, commit and push your changes (including the `docs`
 directory).
 
+## Updating the docker image
+
+If you need to make any changes to the docker image (i.e. if you make any
+changes to the Dockerfile or Gemfile), please run `make docker-push` to update
+the image on [Docker Hub][] (You will need to [login to
+dockerhub][docker-login] first).
+
 [branch protection]: https://help.github.com/articles/about-protected-branches/
 [tech-docs-multipage]: https://tdt-documentation.london.cloudapps.digital/multipage.html#repo-folder-structure
 [CircleCI]: https://circleci.com
-
+[Docker Hub]: https://hub.docker.com/
+[docker-login]: https://docs.docker.com/engine/reference/commandline/login/

--- a/makefile
+++ b/makefile
@@ -4,9 +4,11 @@ VERSION := 1.0
 
 .built-docker-image: Dockerfile Gemfile
 	docker build -t $(IMAGE) .
+	touch .built-docker-image
+
+docker-push: .built-docker-image
 	docker tag $(IMAGE) ministryofjustice/$(IMAGE)
 	docker push ministryofjustice/$(IMAGE)
-	touch .built-docker-image
 
 server: .built-docker-image
 	docker run \


### PR DESCRIPTION
We shouldn't push the docker image to docker hub
every time anyone runs 'make server' to do local
development on the user guide.

This commit extracts that function to a separate
makefile target, and adds instructions to the
README.