### PR TITLE
Mount local config directory when serving/building

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,6 +15,7 @@ server: .built-docker-image
 		-p 4567:4567 \
 		-v $$(pwd)/source:/app/source \
 		-v $$(pwd)/docs:/app/docs \
+		-v $$(pwd)/config:/app/config \
 		-it \
 		$(IMAGE) bundle exec middleman server
 
@@ -26,6 +27,7 @@ build: .built-docker-image
 	docker run \
 		-v $$(pwd)/source:/app/source \
 		-v $$(pwd)/docs:/app/docs \
+		-v $$(pwd)/config:/app/config \
 		-it \
 		$(IMAGE) bundle exec middleman build --build-dir docs
 	touch docs/.nojekyll


### PR DESCRIPTION
Prior to this change, the config settings used by middleman will
be whatever was in place when the docker image was first built.

So, any subsequent config changes will have no effect.
This change ensures that the latest config settings are used,
whenever the middleman server or build commands are invoked.

The CircleCI build pipeline would not be affected by this
problem, because it is always working from a full checkout
of the source, including whatever is in the config directory.
So, without this change, config changes would have affected the
live version of the user guide, but would not have been visible to
the developer, using the docker image for local development.