### PR TITLE
add warning for module version

### DIFF
--- a/source/documentation/deploying-an-app/add-aws-resources.md
+++ b/source/documentation/deploying-an-app/add-aws-resources.md
@@ -11,10 +11,11 @@ The updated list of terraform modules provided by the MoJ are available here : [
 ``` 
  !!!  WARNING  !!!
 
-Be aware that the latest version of these module will only be compatible with Live-1. 
+Be aware that the latest version of these modules will only be compatible with Live-1. 
 If you are planing on deploying them against Live-0, please read their respective README carefully for instruction.
 
 ``` 
+
 ### Usage
 
 In each terraform module repository, you will find a directory named `example` which includes sample configuration for use in Cloud Platform.

--- a/source/documentation/deploying-an-app/add-aws-resources.md
+++ b/source/documentation/deploying-an-app/add-aws-resources.md
@@ -6,15 +6,15 @@ The documentation for the modules lives in each module's repository and you can 
 
 ### Available modules
 
-- [ECR Repository](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials)
-- [S3 Bucket](https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket)
-- [RDS instance](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance)
-- [Elasticache Redis Cluster](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster)
-- [DynamoDB Table](https://github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster)
-- [SNS Topic](https://github.com/ministryofjustice/cloud-platform-terraform-sns-topic)
-- [SQS Queue](https://github.com/ministryofjustice/cloud-platform-terraform-sqs)
-- [MQ Broker](https://github.com/ministryofjustice/cloud-platform-terraform-amq-broker)
+The updated list of terraform modules provided by the MoJ are available here : [Terraform Module](https://github.com/ministryofjustice/cloud-platform#terraform-modules)
 
+``` 
+ !!!  WARNING  !!!
+
+Be aware that the latest version of these module will only be compatible with Live-1. 
+If you are planing on deploying them against Live-0, please read their respective README carefully for instruction.
+
+``` 
 ### Usage
 
 In each terraform module repository, you will find a directory named `example` which includes sample configuration for use in Cloud Platform.


### PR DESCRIPTION
-  Replaced module description with link to main cloud-platform Readme
-  Add small warning to make sure the right version of the modules is used.