### PR TITLE
Add feedback link

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,6 +9,7 @@ phase: INTERNAL
 
 # Links to show on right-hand-side of header
 header_links:
+  'Feedback / Report a problem': 'mailto:platforms+user-guide@digital.justice.gov.uk?subject=User+guide+feedback'
   Documentation: /
   GitHub: https://github.com/ministryofjustice/cloud-platform-user-guide
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,7 +9,11 @@ phase: INTERNAL
 
 # Links to show on right-hand-side of header
 header_links:
+  # This mailto link must contain the text 'Feedback' in order to trigger the javascript
+  # function in source/layouts/custom.erb which adds the current window.location to the
+  # body of the resulting email message.
   'Feedback / Report a problem': 'mailto:platforms+user-guide@digital.justice.gov.uk?subject=User+guide+feedback'
+
   Documentation: /
   GitHub: https://github.com/ministryofjustice/cloud-platform-user-guide
 

--- a/source/archive.html.md.erb
+++ b/source/archive.html.md.erb
@@ -7,17 +7,12 @@ weight: 60
 
 <%= partial 'documentation/getting-started/index' %>
 <%= partial 'documentation/getting-started/kubectl-config' %>
-<%= partial 'documentation/getting-started/env-create' %>
-<%= partial 'documentation/getting-started/ecr-setup' %>
 
 
 
 <%= partial 'documentation/deploying-an-app/index' %>
 <%= partial 'documentation/deploying-an-app/prerequisite' %>
-<%= partial 'documentation/deploying-an-app/helloworld-app-deploy' %>
-<%= partial 'documentation/deploying-an-app/multicontainer-app-deploy' %>
 <%= partial 'documentation/deploying-an-app/app-deploy-helm' %>
-<%= partial 'documentation/deploying-an-app/add-secrets-to-deployment' %>
 <%= partial 'documentation/deploying-an-app/use-circleci-to-upgrade-app' %>
 <%= partial 'documentation/deploying-an-app/add-aws-resources' %>
 <%= partial 'documentation/deploying-an-app/cleaning-up' %>

--- a/source/documentation/deploying-an-app/add-secrets-to-deployment.md
+++ b/source/documentation/deploying-an-app/add-secrets-to-deployment.md
@@ -1,10 +1,10 @@
-### Adding a secret to an application
+## Adding a secret to an application
 
-#### Overview
+### Overview
 
 The aim of this guide is to walkthrough the process of adding a secret (in this example for aws access-key credentials) to a previously deployed application in the Cloud Platform.
 
-#### Prerequisites
+### Prerequisites
 
 This guide assumes the following:
 
@@ -12,16 +12,16 @@ This guide assumes the following:
 * You have previously deployed your application. See [Deploying an application to the Cloud-Platform][deploy-hello-world]
 * Check your deployment is running. See [Interacting with the application][interact-with-app]
 
-#### Configuring secrets
+### Configuring secrets
 
 The following is an example of encoding (configuring) aws access-key credentials in your deployment.
-See [kuberenetes using secrets as environment variables](https://kubernetes.io/docs/concepts/configuration/secret/###using-secrets-as-environment-variables)
+See [kuberenetes using secrets as environment variables](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables)
 
 for detailed information regarding providing base64 values in secret objects to Kuberenetes pods)
 
 Create your AWS Credentials access key (making a note of the aws_access_key_id and aws_secret_access_key)
 
-##### base64-encode your secret as follows:
+#### base64-encode your secret as follows:
 
 In this example  aws_access_key_id is 'AKIAFTKSAW15HJLOGD'. Issue the following command to base64-encode:
 
@@ -39,7 +39,7 @@ echo -n 'QUtJQUZUS1NBVzE1SEpMT0dE' | base64 -b0
 
 This will return the encoded secret 'UVV0SlFVWlVTMU5CVnpFMVNFcE1UMGRF'
 
-#### Creating the secret
+### Creating the secret
 
 Create a secrets.yaml file similar to:
 
@@ -108,6 +108,6 @@ Add the AWS_ACCESS_KEY_ID referencing 'aws_access_key_id' and AWS_SECRET_ACCESS_
                   key: aws_secret_access_key
 ```
 
-[env-create]: getting-started.html##creating-a-cloud-platform-environment
-[deploy-hello-world]: deploying-applications.html##deploying-a-39-hello-world-39-application-to-the-cloud-platform
-[interact-with-app]: deploying-applications.html##interacting-with-the-application
+[env-create]: tasks.html#creating-a-cloud-platform-environment
+[deploy-hello-world]: tasks.html#deploying-a-39-hello-world-39-application-to-the-cloud-platform
+[interact-with-app]: tasks.html#interacting-with-the-application

--- a/source/documentation/deploying-an-app/app-deploy-helm.md
+++ b/source/documentation/deploying-an-app/app-deploy-helm.md
@@ -198,5 +198,5 @@ And then confirm the pods are terminating as expected:
 #### Next steps
 The next step will be to create your own Helm Chart. You can try this with an application of your own or run through [Bitnami's excellent guide](https://docs.bitnami.com/kubernetes/how-to/create-your-first-helm-chart/) on how to build using a simple quickstart.
 
-[env-create]: getting-started.html##creating-a-cloud-platform-environment
-[auth-to-cluster]: getting-started.html##authentication
+[env-create]: tasks.html#creating-a-cloud-platform-environment
+[auth-to-cluster]: tasks.html#authentication

--- a/source/documentation/deploying-an-app/helloworld-app-deploy.md
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.md
@@ -243,6 +243,6 @@ Note: You need the `-L` flag to make curl follow the 308 redirect response that 
 [docker]: https://www.docker.com
 [circleci]: https://circleci.com
 [travisci]: https://travis-ci.org
-[ecr-setup]: getting-started.html##creating-an-ecr-repository
-[access-ecr-credentials]: getting-started.html##accessing-the-credentials
-[env-create]: getting-started.html##creating-a-cloud-platform-environment
+[ecr-setup]: tasks.html#creating-an-ecr-repository
+[access-ecr-credentials]: tasks.html#accessing-the-credentials
+[env-create]: tasks.html#creating-a-cloud-platform-environment

--- a/source/documentation/deploying-an-app/multicontainer-app-deploy.md
+++ b/source/documentation/deploying-an-app/multicontainer-app-deploy.md
@@ -71,7 +71,7 @@ You should be able to view the application in your browser at:
 It should behave in the same way as when you were running it locally via docker-compose.
 
 [multi-demo]: https://github.com/ministryofjustice/cloud-platform-multi-container-demo-app
-[multi-demo-readme]: https://github.com/ministryofjustice/cloud-platform-multi-container-demo-app###multi-container-demo-application
+[multi-demo-readme]: https://github.com/ministryofjustice/cloud-platform-multi-container-demo-app#multi-container-demo-application
 [cloudplatform]: https://github.com/ministryofjustice/cloud-platform
 [k8s-deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [k8s-pod]: https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/
@@ -80,5 +80,5 @@ It should behave in the same way as when you were running it locally via docker-
 [ecr]: https://aws.amazon.com/ecr/
 [rds-module]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance
 [cp-env]: https://github.com/ministryofjustice/cloud-platform-environments
-[ecr-setup]: getting-started.html##creating-an-ecr-repository
-[add-aws-resources]: deploying-applications.html##adding-aws-resources-to-your-environment
+[ecr-setup]: tasks.html#creating-an-ecr-repository
+[add-aws-resources]: archive.html#adding-aws-resources-to-your-environment

--- a/source/documentation/deploying-an-app/use-circleci-to-upgrade-app.md
+++ b/source/documentation/deploying-an-app/use-circleci-to-upgrade-app.md
@@ -116,6 +116,6 @@ deploy_development:
           fi
 ```
 
-[deploy-helm]: deploying-applications.html##deploying-an-application-to-the-cloud-platform-with-helm
-[ecr-setup]: getting-started.html##creating-an-ecr-repository
-[env-create]: getting-started.html##creating-a-cloud-platform-environment
+[deploy-helm]: archive.html#deploying-an-application-to-the-cloud-platform-with-helm
+[ecr-setup]: tasks.html#creating-an-ecr-repository
+[env-create]: tasks.html#creating-a-cloud-platform-environment

--- a/source/documentation/getting-started/ecr-setup.md
+++ b/source/documentation/getting-started/ecr-setup.md
@@ -1,12 +1,12 @@
-### Creating an ECR repository
+## Creating an ECR repository
 
-#### Introduction
+### Introduction
 
 This guide will guide you through the creation of an ECR (Elastic Container Registry) repository for your application's docker image.
 
 AWS resources are provisioned through the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/) repository, per environment. Your application might be using multiple namespaces, however you typically only need one image repository and once created in any of them you can copy credentials for it to the others via `kubectl get/create secret`.
 
-##### Creating the registry
+#### Creating the registry
 
 1\. In order to create the ECR Docker registry, git clone the repo and create a new branch.
 
@@ -42,7 +42,7 @@ AWS resources are provisioned through the [cloud-platform-environments](https://
 
 4\. Adapt the definition from the example described in the [cloud-platform-terraform-ecr-credentials module](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/tree/master/examples); make sure you adjust the values of `team_name`, `repo_name` `name` and `namespace` to what is appropriate for your environment.
 
-Note: A default ECR lifecycle policy is set, that will only keep the 40 most recent versions of an image. More infomation on the ECR lifecycle policy avalible [here.](other-topics.html##ecr-lifecycle-policy)
+Note: A default ECR lifecycle policy is set, that will only keep the 40 most recent versions of an image. More infomation on the ECR lifecycle policy avalible [here.](archive.html#ecr-lifecycle-policy)
 
 5\. git add, commit and push to your branch.
 
@@ -59,7 +59,7 @@ Note: A default ECR lifecycle policy is set, that will only keep the 40 most rec
 
 For more information about the terraform module being used, please read the documentation [here](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials).
 
-#### Accessing the credentials
+### Accessing the credentials
 
 The end result will be a kubernetes `Secret` inside your environment, called `example-team-ecr-credentials-output` (or whatever you changed that to); the secret holds IAM access keys to authenticate with the registry and the actual repository URL.
 
@@ -77,13 +77,13 @@ This can be done at the command line using the following:
 echo QWxhZGRpbjpvcGVuIHNlc2FtZQ== | base64 --decode; echo
 ```
 
-##### Setting up CircleCI
+#### Setting up CircleCI
 In your CircleCI project, go to the settings (the cog icon) and select 'AWS Permissions' from the left hand menu. Fill in the IAM credentials and CircleCI will be able to use ECR images. For more information please see [the official docs](https://circleci.com/docs/2.0/private-images/).
 
 
-#### Next steps
+### Next steps
 
 Try [deploying an app][deploy-helm] with [Helm](https://helm.sh/), a Kubernetes package manager, or [deploying manually][deploy-hello-world] by writing some custom YAML files.
 
-[deploy-hello-world]: deploying-applications.html##deploying-a-39-hello-world-39-application-to-the-cloud-platform
-[deploy-helm]: deploying-applications.html##deploying-an-application-to-the-cloud-platform-with-helm
+[deploy-hello-world]: tasks.html#deploying-a-39-hello-world-39-application-to-the-cloud-platform
+[deploy-helm]: archive.html#deploying-an-application-to-the-cloud-platform-with-helm

--- a/source/documentation/getting-started/env-create.md
+++ b/source/documentation/getting-started/env-create.md
@@ -1,6 +1,6 @@
-### Creating a Cloud Platform Environment
+## Creating a Cloud Platform Environment
 
-#### Introduction
+### Introduction
 
 This is a guide to creating a environment in one of our Kubernetes clusters.
 
@@ -8,11 +8,11 @@ We define an environment as a Kubernetes [namespace](https://kubernetes.io/docs/
 
 Once you have created an environment you will be able to perform actions using the `kubectl` tool in the namespace you have created.
 
-#### Objective
+### Objective
 
 By the end of this guide you'll have created a Kubernetes namespace ready for you to [deploy an application][deploy-hello-world] into.
 
-#### Create an environment
+### Create an environment
 
 You create an environment by adding the definition of the environment in YAML to the following repository, hosted on GitHub:
 
@@ -20,7 +20,7 @@ You create an environment by adding the definition of the environment in YAML to
 
 Adding your environment definition kicks off a pipeline which builds your environment on the appropriate cluster.
 
-##### Set up
+#### Set up
 
 First we need to clone the repository, change directory and create a new branch:
 
@@ -30,7 +30,7 @@ $ cd cloud-platform-environments
 $ git checkout -b <yourBranch>
 ```
 
-##### The directory structure
+#### The directory structure
 
 We build new environments by creating a new directory for our environment and putting the YAML files that define the environment into that directory. To understand where to create the directory it is useful to understand the overall structure of the repo:
 
@@ -60,21 +60,21 @@ Within the cluster directory you will generate a directory for your environment 
 
 **/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/servicename-env/**
 
-The `<servicename-env>` directory for your environment defines the specific resources we will create in your namespace. We describe these resources in more detail in [how we set up an environment](###how-we-set-up-an-environment).
+The `<servicename-env>` directory for your environment defines the specific resources we will create in your namespace. We describe these resources in more detail in [how we set up an environment](#how-we-set-up-an-environment).
 
-##### How we set up an environment
+#### How we set up an environment
 
 To set up an environment we create 5 files in the directory for your namespace:
 
-* [`00-namespace.yaml`](###00-namespaceyaml)
-* [`01-rbac.yaml`](###01-rbacyaml)
-* [`02-limitrange.yaml`](###02-limitrangeyaml)
-* [`03-resourcequota.yaml`](###03-resourcequotayaml)
-* [`04-networkpolicy.yaml`](###04-networkpolicyyaml)
+* [`00-namespace.yaml`](#00-namespace-yaml)
+* [`01-rbac.yaml`](#01-rbac-yaml)
+* [`02-limitrange.yaml`](#02-limitrange-yaml)
+* [`03-resourcequota.yaml`](#03-resourcequota-yaml)
+* [`04-networkpolicy.yaml`](#04-networkpolicy-yaml)
 
-These files define key elements of the namespace and restrictions we want to place on it so that we have security and resource allocation properties. We will use terraform to create these files from templates. We also describe each of these files [in more detail below](###00-namespaceyaml) in case you want to make future changes.
+These files define key elements of the namespace and restrictions we want to place on it so that we have security and resource allocation properties. We will use terraform to create these files from templates. We also describe each of these files [in more detail below](#00-namespace-yaml) in case you want to make future changes.
 
-##### Create your namespace and namespace resources
+#### Create your namespace and namespace resources
 
 We automate the creation of the namespace resource files using terraform. You will need to install terraform locally:
 
@@ -131,9 +131,9 @@ At the final prompt "Do you want to perform these actions?", enter "yes"
 
 You can then access your namespace files under `cloud-platform-environments/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/<your-namespace>`, if satisfied you can then push the changes to your branch and create a pull request against the [`cloud-platform-environments`](https://github.com/ministryofjustice/cloud-platform-environments) master repo.
 
-The cloud platform team will review the pull request when it gets opened.  As soon as the pull request has been approved by the cloud platform team you can then merge it into the master branch which will kick off the pipeline that builds the environment. You can check whether the build succeeded or failed in the [`##cp-build-notification`](https://mojdt.slack.com/messages/CA5MDLM34/) slack channel. This can take about 5 minutes.
+The cloud platform team will review the pull request when it gets opened.  As soon as the pull request has been approved by the cloud platform team you can then merge it into the master branch which will kick off the pipeline that builds the environment. You can check whether the build succeeded or failed in the [`#cp-build-notification`](https://mojdt.slack.com/messages/CA5MDLM34/) slack channel. This can take about 5 minutes.
 
-#### Accessing your environments
+### Accessing your environments
 
 Once the pipeline has completed you will be able to check that your environment is available by running:
 
@@ -147,25 +147,25 @@ You can now run commands in your namespace by appending the `-n` or `--namespace
 
 `$ kubectl get pods --namespace myenv-dev`
 
-#### Next steps
+### Next steps
 
 [Create an ECR repository][ecr-setup] to push your application docker image to.
 
 Then you can try [deploying an app to Kubernetes manually][deploy-hello-world] by writing some custom YAML files or [deploying an app with Helm][deploy-helm], a Kubernetes [package manager]((https://helm.sh/)).
 
-#### More information on environment definition
+### More information on environment definition
 
 To set up an environment we create 5 files in that directory:
 
-* [`00-namespace.yaml`](###00-namespaceyaml)
-* [`01-rbac.yaml`](###01-rbacyaml)
-* [`02-limitrange.yaml`](###02-limitrangeyaml)
-* [`03-resourcequota.yaml`](###03-resourcequotayaml)
-* [`04-networkpolicy.yaml`](###04-networkpolicyyaml)
+* [`00-namespace.yaml`](#00-namespace-yaml)
+* [`01-rbac.yaml`](#01-rbac-yaml)
+* [`02-limitrange.yaml`](#02-limitrange-yaml)
+* [`03-resourcequota.yaml`](#03-resourcequota-yaml)
+* [`04-networkpolicy.yaml`](#04-networkpolicy-yaml)
 
 These files define key elements of the namespace and restrictions we want to place on it so that we have security and resource allocation properties. We will use terraform to create these files from templates. We also describe each of these files in more detail below in case you want to make changes.
 
-##### `00-namespace.yaml`
+#### `00-namespace.yaml`
 
 The `00-namespace.yaml` file defines the namespace so that the cluster Kubernetes knows to create a namespace and what to call it.
 
@@ -178,7 +178,7 @@ metadata:
     name: myapp-dev ### Also your <servicename-env>
 ```
 
-##### `01-rbac.yaml`
+#### `01-rbac.yaml`
 
 We will also create a `RoleBinding` resource by adding the `01-rbac.yaml` file. This will provide us with [access policies](https://kubernetes.io/docs/admin/authorization/rbac/) on the namespace we have created in the cluster.
 
@@ -202,7 +202,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-##### `02-limitrange.yaml`
+#### `02-limitrange.yaml`
 
 As we are working on a shared Kubernetes cluster it is useful to put in place limits on the resources that each namespace, pod and container can use. This helps to stop us accidentally entering a situation where one service impacts the performance of another through using more resources than are available.
 
@@ -229,7 +229,7 @@ spec:
     type: Container
 ```
 
-##### `03-resourcequota.yaml`
+#### `03-resourcequota.yaml`
 
 The [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) object allows us to set a total limit on the resources used in a namespace. As with the LimitRange, the `requests.cpu` and `requests.memory` limits set how much the namespace will request on creation. The `limits.cpu` and `limits.memory` define the overall hard limits for the namespace.
 
@@ -249,7 +249,7 @@ spec:
     limits.memory: 12Gi
 ```
 
-##### `04-networkpolicy.yaml`
+#### `04-networkpolicy.yaml`
 
 The [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) object defines how groups of pods are allowed to communicate with each other and other network endpoints. By default pods are non-isolated, they accept traffic from any source. We apply a network policy to restrict where traffic can come from, allowing traffic only from the [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress/) and other pods in your namespace.
 
@@ -284,6 +284,6 @@ spec:
           component: ingress-controllers
 ```
 
-[deploy-hello-world]: deploying-applications.html##deploying-a-39-hello-world-39-application-to-the-cloud-platform
-[deploy-helm]: deploying-applications.html##deploying-an-application-to-the-cloud-platform-with-helm
-[ecr-setup]: getting-started.html##creating-an-ecr-repository
+[deploy-hello-world]: tasks.html#deploying-a-39-hello-world-39-application-to-the-cloud-platform
+[deploy-helm]: archive.html#deploying-an-application-to-the-cloud-platform-with-helm
+[ecr-setup]: tasks.html#creating-an-ecr-repository

--- a/source/documentation/monitoring-an-app/how-to-create-alarms.md
+++ b/source/documentation/monitoring-an-app/how-to-create-alarms.md
@@ -103,4 +103,4 @@ PrometheusRules can still be tested/amended/applied manually, then a PR can be c
 - [Prometheus Operator - Getting Started](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md)
 - [Alerting](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)
 
-[env-create]: getting-started.html##creating-a-cloud-platform-environment
+[env-create]: tasks.html#creating-a-cloud-platform-environment

--- a/source/documentation/other-topics/k8s-basics.md
+++ b/source/documentation/other-topics/k8s-basics.md
@@ -34,7 +34,7 @@ Kubernetes is normally used with one of the big 3 cloud providers. Amazon Web Se
 
 Kubernetes has it's own official CLI tool for interacting with a Cluster called `kubectl`. It is certainly worth learning the basics of `kubectl`, As the vast majority of time interacting with Kubernetes will be through this tool.
 
-We have our own page on [Kubectl Basics](/other-topics.html##kubectl-quick-reference).
+We have our own page on [Kubectl Basics](/other-topics.html#kubectl-quick-reference).
 
 #### Online Courses
 

--- a/source/documentation/other-topics/secrets.md
+++ b/source/documentation/other-topics/secrets.md
@@ -25,4 +25,4 @@ This kind of secrets falls under the shared responsibility model:
 
 - the Cloud Platform team, on the other hand, is responsible for ensuring the secrets remain secure inside the environment.
 
-[git-crypt]: other-topics.html##git-crypt
+[git-crypt]: archive.html#git-crypt

--- a/source/layouts/custom.erb
+++ b/source/layouts/custom.erb
@@ -1,3 +1,22 @@
 <% wrap_layout :layout do %>
   <%= yield %>
 <% end %>
+
+<script>
+  // Add the current window.location to the body of the
+  // feedback email message.
+  function sendFeedback(mailto, event) {
+    event.preventDefault();
+
+    var body = "Feedback/Problem on page: " + window.location + "\n";
+    var href = mailto + '&body=' + encodeURIComponent(body);
+
+    window.location = href;
+  }
+
+  $(document).ready(function() {
+    var feedbackLink = $('a[href^="mailto:"]:contains("Feedback")')[0];
+    var mailto = feedbackLink.href;
+    $(feedbackLink).on('click', function(event) { sendFeedback(mailto, event); });
+  });
+</script>

--- a/source/tasks.html.md.erb
+++ b/source/tasks.html.md.erb
@@ -7,4 +7,15 @@ weight: 30
 
 This is a placeholder page, into which content will be migrated.
 
-Please look in the [archive section](archive.html) to find existing content.
+Please look in the [archive section](archive.html) to find existing content
+which is yet to be moved.
+
+<%= partial 'documentation/getting-started/env-create' %>
+<%= partial 'documentation/getting-started/ecr-setup' %>
+
+<%= partial 'documentation/deploying-an-app/index' %>
+<%= partial 'documentation/deploying-an-app/helloworld-app-deploy' %>
+<%= partial 'documentation/deploying-an-app/multicontainer-app-deploy' %>
+
+<%= partial 'documentation/deploying-an-app/add-secrets-to-deployment' %>
+


### PR DESCRIPTION
This commit adds a "Feedback / Report a problem" mailto link in the header of the guide.

The javascript code adds the current window.location to the body of the email message, which should make it easier for us to find the part of the guide with the problem in it.

The mailto + body syntax is not supported on all email clients, but I don't think it should cause any problems on clients that don't support it - the email body will just not be pre-populated.

I have only tested this on Chrome, with Gmail as the registered handler for mailto links.

fixes #17 
