### PR TITLE
Add feedback channel

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,6 +9,7 @@ phase: INTERNAL
 
 # Links to show on right-hand-side of header
 header_links:
+  'Feedback / Report a problem': 'mailto:platforms+user-guide@digital.justice.gov.uk?subject=User+guide+feedback'
   Documentation: /
   GitHub: https://github.com/ministryofjustice/cloud-platform-user-guide
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,7 +9,11 @@ phase: INTERNAL
 
 # Links to show on right-hand-side of header
 header_links:
+  # This mailto link must contain the text 'Feedback' in order to trigger the javascript
+  # function in source/layouts/custom.erb which adds the current window.location to the
+  # body of the resulting email message.
   'Feedback / Report a problem': 'mailto:platforms+user-guide@digital.justice.gov.uk?subject=User+guide+feedback'
+
   Documentation: /
   GitHub: https://github.com/ministryofjustice/cloud-platform-user-guide
 

--- a/source/layouts/custom.erb
+++ b/source/layouts/custom.erb
@@ -1,3 +1,22 @@
 <% wrap_layout :layout do %>
   <%= yield %>
 <% end %>
+
+<script>
+  // Add the current window.location to the body of the
+  // feedback email message.
+  function sendFeedback(mailto, event) {
+    event.preventDefault();
+
+    var body = "Feedback/Problem on page: " + window.location + "\n";
+    var href = mailto + '&body=' + encodeURIComponent(body);
+
+    window.location = href;
+  }
+
+  $(document).ready(function() {
+    var feedbackLink = $('a[href^="mailto:"]:contains("Feedback")')[0];
+    var mailto = feedbackLink.href;
+    $(feedbackLink).on('click', function(event) { sendFeedback(mailto, event); });
+  });
+</script>


### PR DESCRIPTION
This commit adds a "Feedback / Report a problem" mailto link in the header of the guide.

The javascript code adds the current window.location to the body of the email message, which should make it easier for us to find the part of the guide with the problem in it.

The mailto + body syntax is not supported on all email clients, but I don't think it should cause any problems on clients that don't support it - the email body will just not be pre-populated.

I have only tested this on Chrome, with Gmail as the registered handler for mailto links.

fixes #17