### PR TITLE
Add live-1 migration checklist first draft

### DIFF
--- a/source/archive.html.md.erb
+++ b/source/archive.html.md.erb
@@ -44,3 +44,4 @@ weight: 60
 <%= partial 'documentation/other-topics/ip-whitelisting' %>
 <%= partial 'documentation/other-topics/ecr-lifecycle-policy' %>
 <%= partial 'documentation/other-topics/maintenance-page' %>
+<%= partial 'documentation/other-topics/live1-migration-guide' %>

--- a/source/documentation/other-topics/live1-migration-guide.md
+++ b/source/documentation/other-topics/live1-migration-guide.md
@@ -30,7 +30,7 @@ You should now be able to switch contexts between the `live-0` and `live-1` clus
 
 Start by following the guide to generate a new environment, this follows the same process as was followed for `live-0`, and you should use the same details as you did for your environment then.
 
-[Enviroment generation guide.](tasks.html#create-an-environment)
+[Environment generation guide.](tasks.html#create-an-environment)
 
 Run a `kubectl get namespaces` to check your environment has been successfully created.
 

--- a/source/documentation/other-topics/live1-migration-guide.md
+++ b/source/documentation/other-topics/live1-migration-guide.md
@@ -30,7 +30,7 @@ You should now be able to switch contexts between the `live-0` and `live-1` clus
 
 Start by following the guide to generate a new environment, this follows the same process as was followed for `live-0`, and you should use the same details as you did for your environment then.
 
-[Enviroment generation guide.](env-create)
+[Enviroment generation guide.](tasks.html#create-an-environment)
 
 Run a `kubectl get namespaces` to check your environment has been successfully created.
 
@@ -40,7 +40,7 @@ Once you've generated a new environment in the `live-1` cluster, you will need t
 
 The reason why the previous ECR repo can't be used is due to the new `live-1` cluster being hosted in a separate AWS account. 
 
-If you need reminding of the ECR creation process, please see the [user documentation](ecr-setup).
+If you need reminding of the ECR creation process, please see the [user documentation](tasks.html#creating-an-ecr-repository).
 
 ### Changing the CircleCI environment variables
 
@@ -65,12 +65,8 @@ After triggering the CircleCI pipeline, your application should now deploy into 
 
 ### Deleting your Live-0 deployment
 
-The last thing you will need to do is to delete your application from the `live-0` cluster. Please action the 3 steps below:
+The last thing you will need to do is to delete your application from the `live-0` cluster.
 
-1. Run `helm delete --purge` or `kubectl delete` reversing the deployment commands.
-
-2. Delete all Terraform files in `resources/` except for main.tf - this will make Terraform delete all AWS resources on the next pipeline run
-
-3. Delete the `namespace` folder, which will remove any leftovers.
+Please see the documentation on [cleaning up within the Cloud Platform](archive.html#cleaning-up).
 
 ### Other considerations 

--- a/source/documentation/other-topics/live1-migration-guide.md
+++ b/source/documentation/other-topics/live1-migration-guide.md
@@ -48,6 +48,8 @@ Now that you have a new empty environment and ECR repository set-up, the next st
 
 This is done by replacing the CircleCI environment variables with the ones generated for your `live-1` environment and then rerunning the pipeline.
 
+Our helper script expects environment variables to be named according to the list below where `<ENVIRONMENT>` should be replaced by some identifier of your choosing (eg.: `STAGING`, `PRODUCTION`).
+
 The environment variables you will need to replace are as follows:
 
 | Variable   |            |
@@ -56,10 +58,10 @@ The environment variables you will need to replace are as follows:
 | `AWS_ACCESS_KEY_ID` | The access key can be found in the secret created by the ECR generation. This requires base64 decoding.   |
 | `AWS_SECRET_ACCESS_KEY` |  The secret key can be found in the secret created by the ECR generation. This requires base64 decoding. |
 | `ECR_ENDPOINT` |    The ECR endpoint for all repos in `live-1` is `754256621582.dkr.ecr.eu-west-2.amazonaws.com`   |
-| `K8S_CLUSTER_CERT` |  The cert is an attribute found in the `default-token` secret and does not need base64 decoding. |
-| `K8S_CLUSTER_NAME` |    The cluster name is `live-1.cloud-platform.service.justice.gov.uk`  |
-| `K8S_NAMESPACE` |  This variable should be equal to the name of your namespace. |
-| `K8S_TOKEN` |    The token is another attribute found in the `default-token` secret and needs base64 decoding.   |
+| `K8S_<ENVIRONMENT>_CLUSTER_CERT` |  The cert is an attribute found in the `default-token` secret and does not need base64 decoding. |
+| `K8S_<ENVIRONMENT>_CLUSTER_NAME` |    The cluster name is `live-1.cloud-platform.service.justice.gov.uk`  |
+| `K8S_<ENVIRONMENT>_NAMESPACE` |  This variable should be equal to the name of your namespace. |
+| `K8S_<ENVIRONMENT>_TOKEN` |    The token is another attribute found in the `default-token` secret and needs base64 decoding.   |
 
 After triggering the CircleCI pipeline, your application should now deploy into your new environment. 
 

--- a/source/documentation/other-topics/live1-migration-guide.md
+++ b/source/documentation/other-topics/live1-migration-guide.md
@@ -56,10 +56,10 @@ The environment variables you will need to replace are as follows:
 | `AWS_ACCESS_KEY_ID` | The access key can be found in the secret created by the ECR generation. This requires base64 decoding.   |
 | `AWS_SECRET_ACCESS_KEY` |  The secret key can be found in the secret created by the ECR generation. This requires base64 decoding. |
 | `ECR_ENDPOINT` |    The ECR endpoint for all repos in `live-1` is `754256621582.dkr.ecr.eu-west-2.amazonaws.com`   |
-| `K8S_CLUSTER_CERT` |  The cert is found in the `default-token` secret and does not need base64 decoding. |
+| `K8S_CLUSTER_CERT` |  The cert is an attribute found in the `default-token` secret and does not need base64 decoding. |
 | `K8S_CLUSTER_NAME` |    The cluster name is `live-1.cloud-platform.service.justice.gov.uk`  |
 | `K8S_NAMESPACE` |  This variable should be equal to the name of your namespace. |
-| `K8S_TOKEN` |    The token is found in the `default-token` secret and needs base64 decoding.   |
+| `K8S_TOKEN` |    The token is another attribute found in the `default-token` secret and needs base64 decoding.   |
 
 After triggering the CircleCI pipeline, your application should now deploy into your new environment. 
 

--- a/source/documentation/other-topics/live1-migration-guide.md
+++ b/source/documentation/other-topics/live1-migration-guide.md
@@ -56,10 +56,10 @@ The environment variables you will need to replace are as follows:
 | `AWS_ACCESS_KEY_ID` | The access key can be found in the secret created by the ECR generation. This requires base64 decoding.   |
 | `AWS_SECRET_ACCESS_KEY` |  The secret key can be found in the secret created by the ECR generation. This requires base64 decoding. |
 | `ECR_ENDPOINT` |    The ECR endpoint for all repos in `live-1` is `754256621582.dkr.ecr.eu-west-2.amazonaws.com`   |
-| `K8S_CLUSTER_CERT` |  The cert is found in the `circleci-token` secret and does not need base64 decoding. |
+| `K8S_CLUSTER_CERT` |  The cert is found in the `default-token` secret and does not need base64 decoding. |
 | `K8S_CLUSTER_NAME` |    The cluster name is `live-1.cloud-platform.service.justice.gov.uk`  |
 | `K8S_NAMESPACE` |  This variable should be equal to the name of your namespace. |
-| `K8S_TOKEN` |    The token is found in the `circleci-token` secret and needs base64 decoding.   |
+| `K8S_TOKEN` |    The token is found in the `default-token` secret and needs base64 decoding.   |
 
 After triggering the CircleCI pipeline, your application should now deploy into your new environment. 
 


### PR DESCRIPTION
This PR connects to the issue ministryofjustice/cloud-platform#662

If merged this PR will add a section in the guide that covers the process of migrating an application from `live-0` to `live-1`.

This guide assumes the guides for environment and ECR generation have been updated for `live-1`.

 