### PR TITLE
Changed reference from live-0 to live-1

### DIFF
--- a/source/documentation/getting-started/ecr-setup.md
+++ b/source/documentation/getting-started/ecr-setup.md
@@ -24,11 +24,11 @@ AWS resources are provisioned through the [cloud-platform-environments](https://
 
 ```bash
 
-  $ cd namespaces/cloud-platform-live-0.k8s.integration.dsd.io/$your_service  ###navigate to your service's directory.
+  $ cd namespaces/live-1.cloud-platform.service.justice.gov.uk/$your_service  ###navigate to your service's directory.
 
   $ mkdir resources ### make directory called resources
 
-  $ cd namespaces/cloud-platform-live-0.k8s.integration.dsd.io/$your_service/resources
+  $ cd namespaces/live-1.cloud-platform.service.justice.gov.uk/$your_service/resources
 
 ```
 


### PR DESCRIPTION
This PR when merged will replace references of `live-0` to `live-1` in the ECR creation document.  