### PR TITLE
kubectl config get-context output format fix

### DIFF
--- a/source/documentation/getting-started/kubectl-config.md
+++ b/source/documentation/getting-started/kubectl-config.md
@@ -56,6 +56,7 @@ If you receive `The connection to the server localhost:8080 was refused` errors 
 check that your "current" context is set.
 
 Run `kubectl config get-contexts`:
+
 ```
 CURRENT   NAME                                           CLUSTER                                        AUTHINFO                 NAMESPACE
           live-1.cloud-platform.service.justice.gov.uk   live-1.cloud-platform.service.justice.gov.uk   <your github e-mail>


### PR DESCRIPTION
This PR will fix a formatting problem with displaying the output of `kubectl config get-contexts` in the user guide.
This problem has caused confusion to a user.