### PR TITLE
Add Pingdom "How to" Documentation

### DIFF
--- a/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.md
+++ b/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.md
@@ -36,14 +36,16 @@ resource "pingdom_check" "cloud-platform-prometheus-live-0-healthcheck" {
 ```
 **Note**: You'll need to include the `provider "pingdom"` and `terraform` blocks either in this file or in a `main.tf` file. 
 
+This basic check simply checks that the host/url (in this case; https://prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io/-/healthy) returns a 200 every minute (resolution = 1 minute). When six (sendnotificationwhendown = 6) consecutive checks fail it triggers an alarm. As publicreport is set to true, you can view the status of your check by visiting the [public status page](http://pingdom.service.dsd.io), where this check would appear with the name "Prometheus - live-0 - cloud-platform - Healthcheck".
+
+[This](https://github.com/russellcardullo/terraform-provider-pingdom#pingdom-check) page explains all the attributes used in the check.
+ 
+All resources, including Pingdom checks **must** be tagged and adhere to the technical guidance outlined [here](https://github.com/ministryofjustice/technical-guidance/blob/master/standards/documenting-infrastructure-owners.md). Ensure your check has appropriate tags before submitting a pull request.
+
 Once reviewed and merged to master, the pipeline will create your check in the MoJ Pingdom account.
 
-This basic check simply checks the `host`/`url` returns a 200 every minute. When six consecutive checks fail it triggers an alarm. As `publicreport` is set to true, you can view the status of your check by visiting the [public status page](http://pingdom.service.dsd.io).
-
-To fully understand all common and uncommon attributes of a check, you can visit the [Pindom community provider](https://github.com/russellcardullo/terraform-provider-pingdom#pingdom-check).
-
 #### Adding Slack notification
-You can enable the option to send a failing alert to Slack via a webhook by simply adding Pingdom integration id. Unfortunately, you need access to the console to first create the [Pingdom Slack](https://mojdt.slack.com/apps/A0F814AV7-pingdom?next_id=0) webhook and then [Pingdom](https://my.pingdom.com) to create the integration id. 
+You can enable the option to send a failing alert to Slack via a webhook by simply adding Pingdom integration id. You need administrator permissions to manage the mojdt [Pingdom Slack](https://mojdt.slack.com/apps/A0F814AV7-pingdom?next_id=0) webhook and then [Pingdom](https://my.pingdom.com) to create the integration id. 
 
 The Cloud Platform team can do this on your behalf. Create a ticket requesting a Pingdom integration id with the following information:
  
@@ -53,7 +55,7 @@ The Cloud Platform team can do this on your behalf. Create a ticket requesting a
  
 The team will provide you with an integration id, following the steps outlined [here](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/docs/creating-pingdom-webhook.md).
 
-You can now add `integrationid` to your `pingdom.tf`. Appending the example above, your check will now appear as follows:
+You can now add `integrationids` to your `pingdom.tf`. Appending the example above, your check will now appear as follows (assuming you were given 1000 as the integration id):
 ```yaml
 terraform {
    backend "s3" {}
@@ -75,7 +77,7 @@ terraform {
     tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_prod,                                          infrastructuresupport_platforms"
     probefilters             = "region:EU"
     publicreport             = "true"
-    integrationid            = [1000]
+    integrationids           = [1000]
   }
 
 ```

--- a/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.md
+++ b/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.md
@@ -1,0 +1,46 @@
+### Creating Pingdom checks
+
+#### Overview
+Pingdom is a global performance and availability monitor for your web application. The aim of this document is to provide you with the necessary information to create and send Pingdom checks to a Slack channel of your choosing.
+
+#### Prerequisites
+This guide assumes the following:
+
+* You have [created a namespace for your application][env-create]
+* You have a slack channel to send alerts into
+
+#### Creating a Pingdom webhook and integration id
+For Pingdom to communicate with Slack you require an integration id. Setting this up is really simple but requires access to the MoJ [Pingdom Slack]() and [Pingdom]() console.
+
+The Cloud Platform team can do this on your behalf. Create a ticket requesting a Pingdom integration id with the following information:
+
+- team name
+- application name
+- slack channel
+
+The team will provide you with an integration id, following the steps outlined [here]().
+
+#### Create a Pingdom terraform file
+In the [cloud-platform-environments]() repository create a resources directory (if it isn't already created)in your namespace, now add a `pingdom.tf` file and using the resources outlined [here](https://github.com/russellcardullo/terraform-provider-pingdom#usage) create a basic check. Here's a working example of a [basic check](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources/pingdom.tf):
+```
+provider "pingdom" {}
+
+resource "pingdom_check" "cloud-platform-prometheus-live-0-healthcheck" {
+  type                     = "http"
+  name                     = "Prometheus - live-0 - cloud-platform - Healthcheck"
+  host                     = "prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/-/healthy"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_prod,infrastructuresupport_platforms"
+  probefilters             = "region:EU"
+  integrationids           = [19203]
+}
+```
+**Note**: You'll need to include the `provider "pingdom"` block either in this file or in a `main.tf` file. 
+ 
+Once reviewed and merged to master, the pipeline will create your check. 

--- a/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.md
+++ b/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.md
@@ -1,46 +1,81 @@
 ### Creating Pingdom checks
 
 #### Overview
-Pingdom is a global performance and availability monitor for your web application. The aim of this document is to provide you with the necessary information to create and send Pingdom checks to a Slack channel of your choosing.
+[Pingdom](https://my.pingdom.com) is a global performance and availability monitor for your web application. The aim of this document is to provide you with the necessary information to create Pingom checks via the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments) pipeline, and then send failing checks to a Slack channel of your choosing.
 
 #### Prerequisites
 This guide assumes the following:
 
 * You have [created a namespace for your application][env-create]
-* You have a slack channel to send alerts into
+* You have a slack channel to send alerts to
 
-#### Creating a Pingdom webhook and integration id
-For Pingdom to communicate with Slack you require an integration id. Setting this up is really simple but requires access to the MoJ [Pingdom Slack](https://mojdt.slack.com/apps/A0F814AV7-pingdom?next_id=0) and [Pingdom](https://my.pingdom.com) console.
+#### Create a Pingdom check
+To create a Pingdom check simply add a `pingdom.tf` file in the resources directory of your namespace in your [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces/live-1.cloud-platform.service.justice.gov.uk) repository. You can define the conditions of your check using the resources outlined in the [Terraform community provider](https://github.com/russellcardullo/terraform-provider-pingdom). Here's a working example of a [basic check](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources).
+```yaml
+terraform {
+  backend "s3" {}
+}
 
-The Cloud Platform team can do this on your behalf. Create a ticket requesting a Pingdom integration id with the following information:
-
-- team name
-- application name
-- slack channel
-
-The team will provide you with an integration id, following the steps outlined [here](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/docs/creating-pingdom-webhook.md).
-
-#### Create a Pingdom terraform file
-In the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments) repository create a resources directory (if it isn't already created) in your namespace, now add a `pingdom.tf` file and using the resources outlined [here](https://github.com/russellcardullo/terraform-provider-pingdom#usage) create a basic check. Here's a working example of a [basic check](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources/pingdom.tf):
-```
 provider "pingdom" {}
 
 resource "pingdom_check" "cloud-platform-prometheus-live-0-healthcheck" {
-  type                     = "http"
-  name                     = "Prometheus - live-0 - cloud-platform - Healthcheck"
-  host                     = "prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io"
-  resolution               = 1
-  notifywhenbackup         = true
-  sendnotificationwhendown = 6
-  notifyagainevery         = 0
-  url                      = "/-/healthy"
-  encryption               = true
-  port                     = 443
-  tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_prod,infrastructuresupport_platforms"
-  probefilters             = "region:EU"
-  integrationids           = [19203]
-}
+   type                     = "http"
+   name                     = "Prometheus - live-0 - cloud-platform - Healthcheck"
+   host                     = "prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io"
+   resolution               = 1
+   notifywhenbackup         = true
+   sendnotificationwhendown = 6
+   notifyagainevery         = 0
+   url                      = "/-/healthy"
+   encryption               = true
+   port                     = 443
+   tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_prod,                              infrastructuresupport_platforms"
+   probefilters             = "region:EU"
+   publicreport             = "true"
+ }
 ```
-**Note**: You'll need to include the `provider "pingdom"` block either in this file or in a `main.tf` file. 
+**Note**: You'll need to include the `provider "pingdom"` and `terraform` blocks either in this file or in a `main.tf` file. 
+
+Once reviewed and merged to master, the pipeline will create your check in the MoJ Pingdom account.
+
+This basic check simply checks the `host`/`url` returns a 200 every minute. When six consecutive checks fail it triggers an alarm. As `publicreport` is set to true, you can view the status of your check by visiting the [public status page](http://pingdom.service.dsd.io).
+
+To fully understand all common and uncommon attributes of a check, you can visit the [Pindom community provider](https://github.com/russellcardullo/terraform-provider-pingdom#pingdom-check).
+
+#### Adding Slack notification
+You can enable the option to send a failing alert to Slack via a webhook by simply adding Pingdom integration id. Unfortunately, you need access to the console to first create the [Pingdom Slack](https://mojdt.slack.com/apps/A0F814AV7-pingdom?next_id=0) webhook and then [Pingdom](https://my.pingdom.com) to create the integration id. 
+
+The Cloud Platform team can do this on your behalf. Create a ticket requesting a Pingdom integration id with the following information:
  
-Once reviewed and merged to master, the pipeline will create your check. 
+  - team name
+  - application name
+  - slack channel
+ 
+The team will provide you with an integration id, following the steps outlined [here](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/docs/creating-pingdom-webhook.md).
+
+You can now add `integrationid` to your `pingdom.tf`. Appending the example above, your check will now appear as follows:
+```yaml
+terraform {
+   backend "s3" {}
+ }
+ 
+ provider "pingdom" {}
+ 
+ resource "pingdom_check" "cloud-platform-prometheus-live-0-healthcheck" {
+    type                     = "http"
+    name                     = "Prometheus - live-0 - cloud-platform - Healthcheck"
+    host                     = "prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io"
+    resolution               = 1
+    notifywhenbackup         = true
+    sendnotificationwhendown = 6
+    notifyagainevery         = 0
+    url                      = "/-/healthy"
+    encryption               = true
+    port                     = 443
+    tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_prod,                                          infrastructuresupport_platforms"
+    probefilters             = "region:EU"
+    publicreport             = "true"
+    integrationid            = [1000]
+  }
+
+```

--- a/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.md
+++ b/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.md
@@ -10,7 +10,7 @@ This guide assumes the following:
 * You have a slack channel to send alerts into
 
 #### Creating a Pingdom webhook and integration id
-For Pingdom to communicate with Slack you require an integration id. Setting this up is really simple but requires access to the MoJ [Pingdom Slack]() and [Pingdom]() console.
+For Pingdom to communicate with Slack you require an integration id. Setting this up is really simple but requires access to the MoJ [Pingdom Slack](https://mojdt.slack.com/apps/A0F814AV7-pingdom?next_id=0) and [Pingdom](https://my.pingdom.com) console.
 
 The Cloud Platform team can do this on your behalf. Create a ticket requesting a Pingdom integration id with the following information:
 
@@ -18,10 +18,10 @@ The Cloud Platform team can do this on your behalf. Create a ticket requesting a
 - application name
 - slack channel
 
-The team will provide you with an integration id, following the steps outlined [here]().
+The team will provide you with an integration id, following the steps outlined [here](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/docs/creating-pingdom-webhook.md).
 
 #### Create a Pingdom terraform file
-In the [cloud-platform-environments]() repository create a resources directory (if it isn't already created)in your namespace, now add a `pingdom.tf` file and using the resources outlined [here](https://github.com/russellcardullo/terraform-provider-pingdom#usage) create a basic check. Here's a working example of a [basic check](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources/pingdom.tf):
+In the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments) repository create a resources directory (if it isn't already created) in your namespace, now add a `pingdom.tf` file and using the resources outlined [here](https://github.com/russellcardullo/terraform-provider-pingdom#usage) create a basic check. Here's a working example of a [basic check](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources/pingdom.tf):
 ```
 provider "pingdom" {}
 


### PR DESCRIPTION
**Overview**
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/756 and finishes the story around users creating Pingdom checks via the environments pipeline. 

The intention of this document is to provide users with instructions on how to create Pingdom checks via the cloud-platform-environments pipeline. 