### PR TITLE
Remove include for 'cleaning up' from archive

### DIFF
--- a/source/archive.html.md.erb
+++ b/source/archive.html.md.erb
@@ -9,7 +9,6 @@ weight: 60
 <%= partial 'documentation/deploying-an-app/prerequisite' %>
 <%= partial 'documentation/deploying-an-app/app-deploy-helm' %>
 <%= partial 'documentation/deploying-an-app/use-circleci-to-upgrade-app' %>
-<%= partial 'documentation/deploying-an-app/cleaning-up' %>
 
 
 


### PR DESCRIPTION
The 'cleaning up' section is already included in the 'tasks' section, so
this include is redundant.