### PR TITLE
Updated ECR lifecycle policy expiry limit information

### DIFF
--- a/source/documentation/getting-started/ecr-setup.md
+++ b/source/documentation/getting-started/ecr-setup.md
@@ -42,7 +42,7 @@ AWS resources are provisioned through the [cloud-platform-environments](https://
 
 4\. Adapt the definition from the example described in the [cloud-platform-terraform-ecr-credentials module](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/tree/master/examples); make sure you adjust the values of `team_name`, `repo_name` `name` and `namespace` to what is appropriate for your environment.
 
-Note: A default ECR lifecycle policy is set, that will only keep the 40 most recent versions of an image. More infomation on the ECR lifecycle policy avalible [here.](tasks.html#ecr-lifecycle-policy)
+Note: A default ECR lifecycle policy is set, that will only keep the 100 most recent versions of an image. More infomation on the ECR lifecycle policy avalible [here.](tasks.html#ecr-lifecycle-policy)
 
 5\. git add, commit and push to your branch.
 

--- a/source/documentation/other-topics/ecr-lifecycle-policy.md
+++ b/source/documentation/other-topics/ecr-lifecycle-policy.md
@@ -5,6 +5,6 @@ ECR repositories created for use in the Cloud Platform will have a default lifec
 
 Due to some applications having a constant rate of images being pushed to their ECR repo, we found that the AWS limit of 1000 images was being hit by some teams.
 
-After consulting with application teams, we decided to implement a lifecycle policy of *40 images* per ECR repo.
+After consulting with application teams, we decided to implement a lifecycle policy of *100 images* per ECR repo.
 
-If you feel that you have a need to archive more than the last 40 images, please contact the Cloud Platform team, who can adjust or remove the lifecycle policy.
+If you feel that you have a need to archive more than the last 100 images, please contact the Cloud Platform team, who can adjust or remove the lifecycle policy.


### PR DESCRIPTION
Updated ECR lifecycle policy expiry limit information, as the limit is changed to 100 now.