### PR TITLE
Update variable names in migration guide

### DIFF
--- a/source/documentation/other-topics/live1-migration-guide.md
+++ b/source/documentation/other-topics/live1-migration-guide.md
@@ -52,6 +52,7 @@ This is done by replacing the CircleCI environment variables with the ones gener
 
 Our helper script expects environment variables to be named according to the list below where `<ENVIRONMENT>` should be replaced by some identifier of your choosing (eg.: `STAGING`, `PRODUCTION`).
 
+Please refer to the instructions [here]() 
 The environment variables you will need to replace are as follows:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
@@ -59,13 +60,13 @@ The environment variables you will need to replace are as follows:
 | Variable   |            |
 |----------|:-------------|
 | `AWS_DEFAULT_REGION` |  The default region will now be `eu-west-2`. |
-| `AWS_ACCESS_KEY_ID` | The access key can be found in the secret created by the ECR generation. This requires base64 decoding.   |
-| `AWS_SECRET_ACCESS_KEY` |  The secret key can be found in the secret created by the ECR generation. This requires base64 decoding. |
-| `ECR_ENDPOINT` |    The ECR endpoint for all repos in `live-1` is `754256621582.dkr.ecr.eu-west-2.amazonaws.com`   |
-| `KUBE_<ENVIRONMENT>_CLUSTER_CERT` |  The cert is an attribute found in the `default-token` secret and does not need base64 decoding. |
-| `KUBE_<ENVIRONMENT>_CLUSTER_NAME` |    The cluster name is `live-1.cloud-platform.service.justice.gov.uk`  |
-| `KUBE_<ENVIRONMENT>_NAMESPACE` |  This variable should be equal to the name of your namespace. |
-| `KUBE_<ENVIRONMENT>_TOKEN` |    The token is another attribute found in the `default-token` secret and needs base64 decoding.   |
+| `AWS_ACCESS_KEY_ID` | The access key can be found in the secret created by the ECR generation. This requires base64 decoding. |
+| `AWS_SECRET_ACCESS_KEY` | The secret key can be found in the secret created by the ECR generation. This requires base64 decoding. |
+| `ECR_ENDPOINT` | The ECR endpoint for all repos in `live-1` is `754256621582.dkr.ecr.eu-west-2.amazonaws.com` |
+| `KUBE_ENV_<ENVIRONMENT>_NAME` | The cluster name is `live-1.cloud-platform.service.justice.gov.uk` |
+| `KUBE_ENV_<ENVIRONMENT>_NAMESPACE` | This variable should be equal to the name of your namespace. |
+| `KUBE_ENV_<ENVIRONMENT>_TOKEN` | The token can be found in your ServiceAccount's `Secret` (eg.: `circleci-token-abcdef`) and needs base64 decoding. |
+| `KUBE_ENV_<ENVIRONMENT>_CACERT` | The cert is an attribute found in the ServiceAccount's `Secret` and does not need base64 decoding. |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 

--- a/source/documentation/other-topics/live1-migration-guide.md
+++ b/source/documentation/other-topics/live1-migration-guide.md
@@ -52,7 +52,7 @@ This is done by replacing the CircleCI environment variables with the ones gener
 
 Our helper script expects environment variables to be named according to the list below where `<ENVIRONMENT>` should be replaced by some identifier of your choosing (eg.: `STAGING`, `PRODUCTION`).
 
-Please refer to the instructions [here]() 
+Please refer to the instructions [here][ug-deploy-to-kubernetes].
 The environment variables you will need to replace are as follows:
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
@@ -93,6 +93,7 @@ See [here][non-root-containers] for more information on non-root containers.
 [ug-create-ecr]: tasks.html#creating-an-ecr-repository
 [ug-create-env]: tasks.html#create-an-environment
 [ug-cleaning-up]: tasks.html#cleaning-up
+[ug-deploy-to-kubernetes]: tasks.html#deploy-to-kubernetes
 [set-kubeconfig-env]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable
 [PodSecurityPolicy]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 [rails-app-dockerfile]: https://github.com/ministryofjustice/cloud-platform-multi-container-demo-app/blob/9ad6caf101cc21117742e5ab2cbe5507efd54efd/rails-app/Dockerfile


### PR DESCRIPTION
In other parts of the guide we're offering instructions based on the `setup-kube-auth` script of the tools image and
refer to this set of environment variables. Other implementations exist (on which the previous variables are based) but
they're not mentioned anywhere else in the guide.