### PR TITLE
Update custom domain documentation

### DIFF
--- a/source/documentation/other-topics/custom-domain-cert.md
+++ b/source/documentation/other-topics/custom-domain-cert.md
@@ -40,6 +40,14 @@ For any other domains (including any subdomain of `gov.uk`, eg.: `https://myserv
 you will need to contact the parent zone's administrators to set this up. If in
 doubt, don't hesitate to get in touch with us in `#ask-cloud-platform`.
 
+Please note, once you setup the NS records, you'll be delegating control of the
+zone to the Cloud Platform. Hostnames used by your services (using `Ingresses`)
+will be automatically managed by the cluster.
+
+If you wish to create custom records in your zone you can do so by defining them
+in the [environments repository][env-repo] using the terraform
+[`aws_route53_record`][tf-route53-record] resource.
+
 ##### Obtaining a certificate
 
 1. Create the `Certificate` resource, filling in any placeholders with your
@@ -99,8 +107,6 @@ namespace where the certificate and key material will be stored
 
 3. You will need to update your `Ingress` spec to include the new hostname.
 
-   **Once your host is defined here, the cluster will take control of the DNS record and automatically adjust to point to the cluster.**
-
    If this does not happen, please get in touch with us in #ask-cloud-platform. Depending on your setup, we might need to
    intervene manually to allow `external-dns` to assume ownership of the DNS record.
 
@@ -135,8 +141,10 @@ namespace where the certificate and key material will be stored
    +           servicePort: 80
    ```
 
+[env-repo]: https://github.com/ministryofjustice/cloud-platform-environments/
 [naming-domains]: https://ministryofjustice.github.io/technical-guidance/standards/naming-domains/#naming-domains
 [creating-zone]: tasks.html#creating-a-route-53-hosted-zone
 [support-ticket]: http://goo.gl/msfGiS
 [wiki-domain-structure]: https://en.wikipedia.org/wiki/Domain_Name_System#Structure
 [wiki-nameservers]: https://en.wikipedia.org/wiki/Name_server#Authoritative_name_server
+[tf-route53-record]: https://www.terraform.io/docs/providers/aws/r/route53_record.html

--- a/source/documentation/other-topics/custom-domain-cert.md
+++ b/source/documentation/other-topics/custom-domain-cert.md
@@ -141,6 +141,14 @@ namespace where the certificate and key material will be stored
    +           servicePort: 80
    ```
 
+Once you've made the changes to your `Ingress`, the cluster (and more
+specifically, `external-dns`) will update the necessary records defined in it.
+This usually takes less than a minute before you are able to access your
+endpoint. However, depending on the DNS name servers your workstation uses, you
+might need to wait longer or try to "flush" your local DNS cache in order to
+speed up the process. You should search online for the proper method to do so,
+based on your operating system and/or browser.
+
 [env-repo]: https://github.com/ministryofjustice/cloud-platform-environments/
 [naming-domains]: https://ministryofjustice.github.io/technical-guidance/standards/naming-domains/#naming-domains
 [creating-zone]: tasks.html#creating-a-route-53-hosted-zone

--- a/source/documentation/other-topics/custom-domain-cert.md
+++ b/source/documentation/other-topics/custom-domain-cert.md
@@ -25,11 +25,11 @@ of the resources for your production environment, if possible.
 Once the zone is created, you will need to setup the necessary NS records in the
 parent DNS zone, before you're able to use it.
 
-If it is a subdomain of `service.justice.gov.uk`, the Cloud Platform team can
-help you set it up; please [create a support ticket][support-ticket].
+If it is a subdomain of `service.justice.gov.uk` (eg.: `https://myapp.service.justice.gov.uk`),
+the Cloud Platform team can help you set it up; please [create a support ticket][support-ticket].
 
-For any other zone (including any other subdomain of `gov.uk`), you will need to
-contact its administrators.
+For any other zone (including any other subdomain of `gov.uk`, eg.: `https://myservice.gov.uk`),
+you will need to contact its administrators.
 
 ##### Obtaining a certificate
 

--- a/source/documentation/other-topics/custom-domain-cert.md
+++ b/source/documentation/other-topics/custom-domain-cert.md
@@ -64,6 +64,30 @@ namespace where the certificate and key material will be stored
    $ kubectl describe certificate <my-cert>
    ```
 
+   The certificate status of type `"Ready"` should be `True`:
+
+   ```
+   Status:
+     Conditions:
+       Last Transition Time:  2019-06-05T10:16:43Z
+       Message:               Certificate is up to date and has not expired
+       Reason:                Ready
+       Status:                True
+       Type:                  Ready
+     Not After:               2019-09-03T09:16:42Z
+   Events:
+     Type    Reason         Age   From          Message
+     ----    ------         ----  ----          -------
+     Normal  Generated      3m    cert-manager  Generated new private key
+     Normal  OrderCreated   3m    cert-manager  Created Order resource "<my-cert>-3189350212"
+     Normal  OrderComplete  1m    cert-manager  Order "<my-cert>-3189350212" completed successfully
+     Normal  CertIssued     1m    cert-manager  Certificate issued successfully
+   ```
+
+   It generally takes but a few minutes for the certificate to be prepared and
+   the events displayed should indicate if there is a problem or it simply needs
+   more time.
+
 3. You will need to update your `Ingress` spec to include the new hostname.
 
    **Once your host is defined here, the cluster will take control of the DNS record and automatically adjust to point to the cluster.**

--- a/source/documentation/other-topics/custom-domain-cert.md
+++ b/source/documentation/other-topics/custom-domain-cert.md
@@ -103,13 +103,10 @@ namespace where the certificate and key material will be stored
 
    It generally takes but a few minutes for the certificate to be prepared and
    the events displayed should indicate if there is a problem or it simply needs
-   more time.
+   more time. If you cannot obtain a certificate, please get in touch with us in
+   `#ask-cloud-platform`.
 
 3. You will need to update your `Ingress` spec to include the new hostname.
-
-   If this does not happen, please get in touch with us in #ask-cloud-platform. Depending on your setup, we might need to
-   intervene manually to allow `external-dns` to assume ownership of the DNS record.
-
 
    ```
      apiVersion: extensions/v1beta1

--- a/source/documentation/other-topics/custom-domain-cert.md
+++ b/source/documentation/other-topics/custom-domain-cert.md
@@ -2,17 +2,22 @@
 
 #### Background
 Every application running on Cloud Platform is able to use a hostname for their
-HTTP endpoints, under a pre-defined DNS zone. For example, on the `live-1`
+HTTP endpoints, under a pre-defined domain. For example, on the `live-1`
 cluster, this would be `*.apps.live-1.cloud-platform.service.justice.gov.uk`. As
-long as it is defined on the `Ingress` resource, it works automatically with a
+long as it is defined on the `Ingress` resource, it works automatically, using a
 wildcard TLS certificate.
 
 However, most applications will typically need to be served on their own,
-application-specific `gov.uk` hostname. These hostnames (or usually, DNS zones)
+application-specific `gov.uk` hostname. These hostnames (or usually, entire domains)
 are managed individually and there is a number of actions in order to set them
 up for usage.
 
 #### Setup
+
+Domains are managed inside DNS zones. You can read more about the structure of
+the Domain Name System in this [page][wiki-domain-structure]. It is recommended
+that applications use their own DNS zones, in order to aid with management and
+provide better isolation.
 
 ##### Defining the DNS zone
 
@@ -20,16 +25,20 @@ To create the zone, you simply need to define it as a resource in your
 environment. Make sure to read [the guidance on naming domains][naming-domains]
 first and follow the instructions to [create the Route53 zone][creating-zone].
 To simplify management, we recommend that you only define a single zone, as part
-of the resources for your production environment, if possible.
+of the resources for your production environment, if possible. You can still use
+subdomains of that zone for different environments.
 
-Once the zone is created, you will need to setup the necessary NS records in the
-parent DNS zone, before you're able to use it.
+Once the zone is created, you will need to setup the necessary name server (NS)
+records in the parent DNS zone, before you're able to use it. For more
+information on how this delegation method works, you can read about authoritative
+name servers in this [page][wiki-nameservers].
 
-If it is a subdomain of `service.justice.gov.uk` (eg.: `https://myapp.service.justice.gov.uk`),
+If your zone is for a subdomain of `service.justice.gov.uk` (eg.: `https://myapp.service.justice.gov.uk`),
 the Cloud Platform team can help you set it up; please [create a support ticket][support-ticket].
 
-For any other zone (including any other subdomain of `gov.uk`, eg.: `https://myservice.gov.uk`),
-you will need to contact its administrators.
+For any other domains (including any subdomain of `gov.uk`, eg.: `https://myservice.gov.uk`),
+you will need to contact the parent zone's administrators to set this up. If in
+doubt, don't hesitate to get in touch with us in `#ask-cloud-platform`.
 
 ##### Obtaining a certificate
 
@@ -129,3 +138,5 @@ namespace where the certificate and key material will be stored
 [naming-domains]: https://ministryofjustice.github.io/technical-guidance/standards/naming-domains/#naming-domains
 [creating-zone]: tasks.html#creating-a-route-53-hosted-zone
 [support-ticket]: http://goo.gl/msfGiS
+[wiki-domain-structure]: https://en.wikipedia.org/wiki/Domain_Name_System#Structure
+[wiki-nameservers]: https://en.wikipedia.org/wiki/Name_server#Authoritative_name_server


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/865

Since the original version of this document, we have refined the process. We will be managing all custom zones in
our cloud-platform account and so regardless of the existing setup, we ask users to define the route53 zone as a
resource.

Managing specific cases (migrating domains, third-party administrators) can be done at the time when the NS records
need to be setup, to delegate control of the zone to our account.

This should simplify the overall process by introducing a single gate: setting up the NS records.