### PR TITLE
Set role for tiller to admin, not cluster-admin

### DIFF
--- a/source/documentation/deploying-an-app/app-deploy-helm.md
+++ b/source/documentation/deploying-an-app/app-deploy-helm.md
@@ -71,7 +71,7 @@ subjects:
   namespace: myapp-dev ### Your namespace `<servicename-env>`
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: admin
   apiGroup: rbac.authorization.k8s.io
 ```
 


### PR DESCRIPTION
The current user guide suggests giving the tiller ServiceAccount
the 'cluster-admin' role, but admin would be a better choice.