### PR TITLE
Stop building the docker image for 'make server'

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,14 +10,14 @@ docker-push: .built-docker-image
 	docker tag $(IMAGE) ministryofjustice/$(IMAGE)
 	docker push ministryofjustice/$(IMAGE)
 
-server: .built-docker-image
+server:
 	docker run \
 		-p 4567:4567 \
 		-v $$(pwd)/source:/app/source \
 		-v $$(pwd)/docs:/app/docs \
 		-v $$(pwd)/config:/app/config \
 		-it \
-		$(IMAGE) bundle exec middleman server
+		ministryofjustice/$(IMAGE):$(VERSION) bundle exec middleman server
 
 # The CircleCI build pipeline does this, so it should never
 # be necessary to run this task. I'm leaving it here for


### PR DESCRIPTION
Most of the time, users will not need to rebuild the docker image,
when writing/modifying articles in the user guide. So, rebuilding
it for every user is a waste of time.

This commit tells the makefile to pull the docker image, rather
than building it, for the 'make server' command.