### PR TITLE
Add first draft of troubleshooting guide

### DIFF
--- a/source/documentation/other-topics/troubleshooting.md
+++ b/source/documentation/other-topics/troubleshooting.md
@@ -2,6 +2,8 @@
 ## Overview
 This document intends to give you an idea of potential troubleshooting tips and techniques to investigate and resolve application issues on the Cloud Platform. The Kubernetes project also offers a resource on [troubleshooting](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/) so we will attempt to avoid overlap. 
 
+Thoughout this document we will refer to terms such as <pod_name> and <namespace>, it is assumed you'll know how to gather this information using the `kubectl get` commands.
+
 ## Contents
 
 ### My pod shows `CreateContainerConfigError` after deployment
@@ -10,7 +12,7 @@ You have deployed an application to the Cloud Platform and its status shows `Cre
 #### Cause
 There are a number of reasons why this error will appear but the most probable cause is a missing secret or environment variable.
 #### Troubleshooting
-To investigate this issue you'll want to investigate the events of your pod. Run `kubectl -n <namespace> describe <pod_name>`. In the section titled `Events` you'll have something similar to:
+To investigate this issue you'll want to look at the events of your pod. Run `kubectl -n <namespace> describe <pod_name>`, in the section titled `Events` you'll have something similar to:
 ```
 Events:
   Type     Reason     Age                    From                                                   Message
@@ -20,4 +22,36 @@ Events:
 ```
 *Note* you can also find this out using `kubectl -n <namespace> get events`
 #### Solution
-Ensure all secrets and environment variables have been defined.  
+Ensure all secrets and environment variables have been defined.
+
+## My pod shows `CrashLoopBackOff` after deployment
+### Scenario
+Following the deployment of your application, you receieve a status of `CrashLoopBackOff` when querying the pods in your namespace with `kubectl get pods -n <namespace>`
+
+### Cause
+A CrashloopBackOff means that you have a pod starting, crashing, starting again, and then crashing again.
+
+A PodSpec has a restartPolicy field with possible values Always, OnFailure, and Never which applies to all containers in a pod. The default value is Always and the restartPolicy only refers to restarts of the containers by the kubelet on the same node (so the restart count will reset if the pod is rescheduled in a different node). Failed containers that are restarted by the kubelet are restarted with an exponential back-off delay (10s, 20s, 40s …) capped at five minutes, and is reset after ten minutes of successful execution. This is an example of a PodSpec with the restartPolicy field:
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy-pod
+spec:
+  containers:
+    - name: dummy-pod
+      image: ubuntu
+  restartPolicy: Always
+```
+
+The main causes of `Crashloopback` are:
+- The application inside the container keeps crashing
+- Some type of parameters of the pod or container have been configured incorrectly
+- An error has been made when deploying Kubernetes
+
+### Troubleshooting
+As this issue is quite vague, you'll want to start by checking STDOUT using the command `kubectl -n <namespace> logs <pod_name>`. This should give you a clear understanding of whether the application has crashed. If this is the case please review the application code and the solution will become evident.
+
+### Solution
+Fix application or misconfiguration errors.
+

--- a/source/documentation/other-topics/troubleshooting.md
+++ b/source/documentation/other-topics/troubleshooting.md
@@ -55,3 +55,19 @@ As this issue is quite vague, you'll want to start by checking STDOUT using the 
 ### Solution
 Fix application or misconfiguration errors.
 
+## My pod shows `ImagePullBackOff` after deployment
+### Scenario
+You have deployed an application to the Cloud Platform and its status shows `ImagePullBackOff` (you can get the status by running `kubect get pods -n <namespace>`).
+
+### Cause
+This error is caused by a misconfiguration in your deployment, usually an invalid image `tag:`.
+
+### Troubleshooting
+Again, utilising the `kubectl -n <namespace> describe <pod_name>` command you can see that the pod has failed to pull down the correct image:
+```
+  Normal   Pulling    10m (x4 over 12m)    kubelet, worker-node  pulling image "redis:foobar"
+  Warning  Failed     10m (x4 over 12m)    kubelet, worker-node  Error: ErrImagePull
+```
+
+### Solution
+This can be corrected by amdending the `image` in your deployment.

--- a/source/documentation/other-topics/troubleshooting.md
+++ b/source/documentation/other-topics/troubleshooting.md
@@ -1,18 +1,28 @@
 ### Troubleshooting guide
+
 #### Overview
 This document intends to give you an idea of potential troubleshooting tips and techniques to investigate and resolve application issues on the Cloud Platform. The Kubernetes project also offers a resource on [troubleshooting](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/) so we will attempt to avoid overlap. 
 
-Thoughout this document we will refer to terms such as <pod_name> and <namespace>, it is assumed you'll know how to gather this information using the `kubectl get` commands.
+Throughout this document we will refer to terms such as <pod_name> and <namespace>, it is assumed you'll know how to gather this information using the `kubectl get` commands.
 
 #### Contents
 
-##### My pod shows `CreateContainerConfigError` after deployment
-###### Scenario
+  - [My pod shows 'CreateContainerConfigError' after deployment](#my-pod-shows-createcontainerconfigerror-after-deployment)
+  - [My pod shows 'CrashLoopBackOff' after deployment](#my-pod-shows-crashloopbackoff-after-deployment)
+  - [My pod shows 'ImagePullBackOff' after deployment](#my-pod-shows-imagepullbackoff-after-deployment)
+  - [I get the error 'container is unhealthy, it will be killed and re-created’](#i-get-the-error-39-container-is-unhealthy-it-will-be-killed-and-re-created-39)
+
+#### My pod shows 'CreateContainerConfigError' after deployment
+
+##### Scenario
 You have deployed an application to the Cloud Platform and its status shows `CreateContainerConfigError` (you can get the status by running `kubect get pods -n <namespace>`). 
-###### Cause
+
+##### Cause
 There are a number of reasons why this error will appear but the most probable cause is a missing secret or environment variable.
-###### Troubleshooting
+
+##### Troubleshooting
 To investigate this issue you'll want to look at the events of your pod. Run `kubectl -n <namespace> describe <pod_name>`, in the section titled `Events` you'll have something similar to:
+
 ```
 Events:
   Type     Reason     Age                    From                                                   Message
@@ -20,18 +30,22 @@ Events:
   Normal   Scheduled  54m                    default-scheduler                                      Successfully assigned myapplication-namespace/myapplication to worker-node
   Warning  Failed     49m (x8 over 53m)      kubelet, worker-node  Error: Couldn't find key postgresUser in Secret myapplication-dev/myapplication
 ```
+
 > Note: you can also find this out using `kubectl -n <namespace> get events`
-###### Solution
+
+##### Solution
 Ensure all secrets and environment variables have been defined.
 
 #### My pod shows `CrashLoopBackOff` after deployment
+
 ##### Scenario
-Following the deployment of your application, you receieve a status of `CrashLoopBackOff` when querying the pods in your namespace with `kubectl get pods -n <namespace>`
+Following the deployment of your application, you receive a status of `CrashLoopBackOff` when querying the pods in your namespace with `kubectl get pods -n <namespace>`.
 
 ##### Cause
-A CrashloopBackOff means that you have a pod starting, crashing, starting again, and then crashing again.
+A `CrashloopBackOff` means that you have a pod starting, crashing, starting again, and then crashing again.
 
 A PodSpec has a restartPolicy field with possible values Always, OnFailure, and Never which applies to all containers in a pod. The default value is Always and the restartPolicy only refers to restarts of the containers by the kubelet on the same node (so the restart count will reset if the pod is rescheduled in a different node). Failed containers that are restarted by the kubelet are restarted with an exponential back-off delay (10s, 20s, 40s …) capped at five minutes, and is reset after ten minutes of successful execution. This is an example of a PodSpec with the restartPolicy field:
+
 ```
 apiVersion: v1
 kind: Pod
@@ -45,9 +59,10 @@ spec:
 ```
 
 The main causes of `Crashloopback` are:
-- The application inside the container keeps crashing
-- Some type of parameters of the pod or container have been configured incorrectly
-- An error has been made when deploying Kubernetes
+
+- The application inside the container keeps crashing.
+- Some type of parameters of the pod or container have been configured incorrectly.
+- An error has been made when deploying Kubernetes.
 
 ##### Troubleshooting
 As this issue is quite vague, you'll want to start by checking STDOUT using the command `kubectl -n <namespace> logs <pod_name>`. This should give you a clear understanding of whether the application has crashed. If this is the case please review the application code and the solution will become evident.
@@ -56,6 +71,7 @@ As this issue is quite vague, you'll want to start by checking STDOUT using the 
 Fix application or misconfiguration errors.
 
 #### My pod shows `ImagePullBackOff` after deployment
+
 ##### Scenario
 You have deployed an application to the Cloud Platform and its status shows `ImagePullBackOff` (you can get the status by running `kubect get pods -n <namespace>`).
 
@@ -70,9 +86,9 @@ Again, utilising the `kubectl -n <namespace> describe <pod_name>` command you ca
 ```
 
 ##### Solution
-This can be corrected by amdending the `image` in your deployment.
+This can be corrected by amending the `image` in your deployment.
 
-#### I get the error `container is unhealthy, it will be killed and re-created`
+#### I get the error 'container is unhealthy, it will be killed and re-created'
 
 ##### Situation
 Your pod appears to be jumping between an `error` and `ready` state. You describe the pod and get an error `container is unhealthy, it will be killed and re-created` 

--- a/source/documentation/other-topics/troubleshooting.md
+++ b/source/documentation/other-topics/troubleshooting.md
@@ -1,17 +1,17 @@
-# Troubleshooting guide
-## Overview
+### Troubleshooting guide
+#### Overview
 This document intends to give you an idea of potential troubleshooting tips and techniques to investigate and resolve application issues on the Cloud Platform. The Kubernetes project also offers a resource on [troubleshooting](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/) so we will attempt to avoid overlap. 
 
 Thoughout this document we will refer to terms such as <pod_name> and <namespace>, it is assumed you'll know how to gather this information using the `kubectl get` commands.
 
-## Contents
+#### Contents
 
-### My pod shows `CreateContainerConfigError` after deployment
-#### Scenario
+##### My pod shows `CreateContainerConfigError` after deployment
+###### Scenario
 You have deployed an application to the Cloud Platform and its status shows `CreateContainerConfigError` (you can get the status by running `kubect get pods -n <namespace>`). 
-#### Cause
+###### Cause
 There are a number of reasons why this error will appear but the most probable cause is a missing secret or environment variable.
-#### Troubleshooting
+###### Troubleshooting
 To investigate this issue you'll want to look at the events of your pod. Run `kubectl -n <namespace> describe <pod_name>`, in the section titled `Events` you'll have something similar to:
 ```
 Events:
@@ -20,15 +20,15 @@ Events:
   Normal   Scheduled  54m                    default-scheduler                                      Successfully assigned myapplication-namespace/myapplication to worker-node
   Warning  Failed     49m (x8 over 53m)      kubelet, worker-node  Error: Couldn't find key postgresUser in Secret myapplication-dev/myapplication
 ```
-*Note* you can also find this out using `kubectl -n <namespace> get events`
-#### Solution
+> Note: you can also find this out using `kubectl -n <namespace> get events`
+###### Solution
 Ensure all secrets and environment variables have been defined.
 
-## My pod shows `CrashLoopBackOff` after deployment
-### Scenario
+#### My pod shows `CrashLoopBackOff` after deployment
+##### Scenario
 Following the deployment of your application, you receieve a status of `CrashLoopBackOff` when querying the pods in your namespace with `kubectl get pods -n <namespace>`
 
-### Cause
+##### Cause
 A CrashloopBackOff means that you have a pod starting, crashing, starting again, and then crashing again.
 
 A PodSpec has a restartPolicy field with possible values Always, OnFailure, and Never which applies to all containers in a pod. The default value is Always and the restartPolicy only refers to restarts of the containers by the kubelet on the same node (so the restart count will reset if the pod is rescheduled in a different node). Failed containers that are restarted by the kubelet are restarted with an exponential back-off delay (10s, 20s, 40s …) capped at five minutes, and is reset after ten minutes of successful execution. This is an example of a PodSpec with the restartPolicy field:
@@ -49,25 +49,47 @@ The main causes of `Crashloopback` are:
 - Some type of parameters of the pod or container have been configured incorrectly
 - An error has been made when deploying Kubernetes
 
-### Troubleshooting
+##### Troubleshooting
 As this issue is quite vague, you'll want to start by checking STDOUT using the command `kubectl -n <namespace> logs <pod_name>`. This should give you a clear understanding of whether the application has crashed. If this is the case please review the application code and the solution will become evident.
 
-### Solution
+##### Solution
 Fix application or misconfiguration errors.
 
-## My pod shows `ImagePullBackOff` after deployment
-### Scenario
+#### My pod shows `ImagePullBackOff` after deployment
+##### Scenario
 You have deployed an application to the Cloud Platform and its status shows `ImagePullBackOff` (you can get the status by running `kubect get pods -n <namespace>`).
 
-### Cause
+##### Cause
 This error is caused by a misconfiguration in your deployment, usually an invalid image `tag:`.
 
-### Troubleshooting
+##### Troubleshooting
 Again, utilising the `kubectl -n <namespace> describe <pod_name>` command you can see that the pod has failed to pull down the correct image:
 ```
   Normal   Pulling    10m (x4 over 12m)    kubelet, worker-node  pulling image "redis:foobar"
   Warning  Failed     10m (x4 over 12m)    kubelet, worker-node  Error: ErrImagePull
 ```
 
-### Solution
+##### Solution
 This can be corrected by amdending the `image` in your deployment.
+
+#### I get the error `container is unhealthy, it will be killed and re-created`
+
+##### Situation
+Your pod appears to be jumping between an `error` and `ready` state. You describe the pod and get an error `container is unhealthy, it will be killed and re-created` 
+
+##### Cause
+Kubernetes provides two essential features called Liveness Probes and Readiness Probes. Essentially, Liveness/Readiness Probes will periodically perform an action (e.g. make an HTTP request, open a tcp connection, or run a command in your container) to confirm that your application is working as intended.
+
+If the Liveness Probe fails, Kubernetes will kill your container and create a new one. If the Readiness Probe fails, that Pod will not be available as a Service endpoint, meaning no traffic will be sent to that Pod until it becomes Ready.
+
+##### Troubleshooting
+Using the log output (`kubectl -n <namespace> <pod_name>`) you should see the cause of your Probe failure. 
+
+There are likely three possibilities:
+
+  -  Your Probes are now incorrect - Did the health URL change?
+  -  Your Probes are too sensitive - Does your application take a while to start or respond?
+  -  Your application is no longer responding correctly to the Probe - Is your database misconfigured?
+
+##### Solution
+Once a change has been made to either your application or Probe, a fresh deployment should succeed.

--- a/source/documentation/other-topics/troubleshooting.md
+++ b/source/documentation/other-topics/troubleshooting.md
@@ -1,9 +1,23 @@
 # Troubleshooting guide
 ## Overview
+This document intends to give you an idea of potential troubleshooting tips and techniques to investigate and resolve application issues on the Cloud Platform. The Kubernetes project also offers a resource on [troubleshooting](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/) so we will attempt to avoid overlap. 
+
 ## Contents
 
-### Troubleshooting x
+### My pod shows `CreateContainerConfigError` after deployment
 #### Scenario
+You have deployed an application to the Cloud Platform and its status shows `CreateContainerConfigError` (you can get the status by running `kubect get pods -n <namespace>`). 
 #### Cause
+There are a number of reasons why this error will appear but the most probable cause is a missing secret or environment variable.
+#### Troubleshooting
+To investigate this issue you'll want to investigate the events of your pod. Run `kubectl -n <namespace> describe <pod_name>`. In the section titled `Events` you'll have something similar to:
+```
+Events:
+  Type     Reason     Age                    From                                                   Message
+  ----     ------     ----                   ----                                                   -------
+  Normal   Scheduled  54m                    default-scheduler                                      Successfully assigned myapplication-namespace/myapplication to worker-node
+  Warning  Failed     49m (x8 over 53m)      kubelet, worker-node  Error: Couldn't find key postgresUser in Secret myapplication-dev/myapplication
+```
+*Note* you can also find this out using `kubectl -n <namespace> get events`
 #### Solution
-
+Ensure all secrets and environment variables have been defined.  

--- a/source/documentation/other-topics/troubleshooting.md
+++ b/source/documentation/other-topics/troubleshooting.md
@@ -3,7 +3,7 @@
 #### Overview
 This document intends to give you an idea of potential troubleshooting tips and techniques to investigate and resolve application issues on the Cloud Platform. The Kubernetes project also offers a resource on [troubleshooting](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/) so we will attempt to avoid overlap. 
 
-Throughout this document we will refer to terms such as <pod_name> and <namespace>, it is assumed you'll know how to gather this information using the `kubectl get` commands.
+Throughout this document we will refer to terms such as `<pod_name>` and `<namespace>`, it is assumed you'll know how to gather this information using the `kubectl get` commands.
 
 #### Contents
 
@@ -58,14 +58,14 @@ spec:
   restartPolicy: Always
 ```
 
-The main causes of `Crashloopback` are:
+The main causes of `CrashloopBackOff` are:
 
 - The application inside the container keeps crashing.
-- Some type of parameters of the pod or container have been configured incorrectly.
+- Some parameters of the pod or container have been configured incorrectly.
 - An error has been made when deploying Kubernetes.
 
 ##### Troubleshooting
-As this issue is quite vague, you'll want to start by checking STDOUT using the command `kubectl -n <namespace> logs <pod_name>`. This should give you a clear understanding of whether the application has crashed. If this is the case please review the application code and the solution will become evident.
+As this issue is quite vague, you'll want to start by checking what your pod is printing to STDOUT using the command `kubectl -n <namespace> logs <pod_name>`. This should give you a clear understanding of whether the application has crashed. If your application is crashing, you need to identify the reason and try to fix it. Some possibilities are missing environment variables, insufficient resources, missing files or directories, or a lack of required permissions.
 
 ##### Solution
 Fix application or misconfiguration errors.
@@ -76,7 +76,11 @@ Fix application or misconfiguration errors.
 You have deployed an application to the Cloud Platform and its status shows `ImagePullBackOff` (you can get the status by running `kubect get pods -n <namespace>`).
 
 ##### Cause
-This error is caused by a misconfiguration in your deployment, usually an invalid image `tag:`.
+This error is caused by a misconfiguration in your deployment, there are three primary culprits besides network connectivity issues:
+
+- The image tag is incorrect
+- The image doesn't exist (or is in a different registry)
+- Kubernetes doesn't have permissions to pull that image
 
 ##### Troubleshooting
 Again, utilising the `kubectl -n <namespace> describe <pod_name>` command you can see that the pod has failed to pull down the correct image:
@@ -94,7 +98,7 @@ This can be corrected by amending the `image` in your deployment.
 Your pod appears to be jumping between an `error` and `ready` state. You describe the pod and get an error `container is unhealthy, it will be killed and re-created` 
 
 ##### Cause
-Kubernetes provides two essential features called Liveness Probes and Readiness Probes. Essentially, Liveness/Readiness Probes will periodically perform an action (e.g. make an HTTP request, open a tcp connection, or run a command in your container) to confirm that your application is working as intended.
+Kubernetes provides two essential features called [Liveness Probes and Readiness Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). Essentially, Liveness/Readiness Probes will periodically perform an action (e.g. make an HTTP request, open a tcp connection, or run a command in your container) to confirm that your application is working as intended.
 
 If the Liveness Probe fails, Kubernetes will kill your container and create a new one. If the Readiness Probe fails, that Pod will not be available as a Service endpoint, meaning no traffic will be sent to that Pod until it becomes Ready.
 

--- a/source/documentation/other-topics/troubleshooting.md
+++ b/source/documentation/other-topics/troubleshooting.md
@@ -1,0 +1,9 @@
+# Troubleshooting guide
+## Overview
+## Contents
+
+### Troubleshooting x
+#### Scenario
+#### Cause
+#### Solution
+

--- a/source/tasks.html.md.erb
+++ b/source/tasks.html.md.erb
@@ -51,4 +51,5 @@ weight: 30
 <%= partial 'documentation/other-topics/maintenance-page' %>
 <%= partial 'documentation/other-topics/statefulsets' %>
 <%= partial 'documentation/other-topics/decommission-unused-template-deploy-services' %>
+<%= partial 'documentation/other-topics/troubleshooting' %>
 <%= partial 'documentation/other-topics/rds-ssl' %>


### PR DESCRIPTION
**Overview**
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/930 and relates to the addition of a troubleshooting guide for users of the Cloud Platform. The intention of this document to  explain, in general terms, how teams can find the key logs, events and metrics they can use to resolve problems with their applications.

**What this PR contains?**
---
When merged to master a `troubleshooting guide` will appear in the cloud platform user guide. There are four sections added as this is all I could think of without overlapping official Kubernetes documentation. 

**What next?** 
---
I will pass this work to a colleague to iterate on this document. 