### PR TITLE
Add a note about naming environments

### DIFF
--- a/source/documentation/getting-started/env-create.md
+++ b/source/documentation/getting-started/env-create.md
@@ -28,6 +28,13 @@ to the following repository, hosted on GitHub:
 Adding your environment definition kicks off a pipeline which builds your
 environment on the appropriate cluster.
 
+> #### Naming
+> When creating your environment, please ensure that you comply with our
+[guidance on naming things][naming-things-guidance].
+
+> This is particularly important for domain names, but since these often closely
+match the namespace name, it's worth choosing a good name at this stage.
+
 #### Set up
 
 First we need to clone the repository, change directory and create a new branch:
@@ -401,3 +408,4 @@ spec:
 [ecr-setup]: tasks.html#creating-an-ecr-repository
 [create-rds]: tasks.html#create-an-rds-instance
 [namespace limits]: concepts.html#namespace-container-resource-limits
+[naming-things-guidance]: https://ministryofjustice.github.io/technical-guidance/standards/naming-things/#naming-things


### PR DESCRIPTION

![Screen Shot 2019-08-16 at 11 22 48](https://user-images.githubusercontent.com/2338/63161550-3906b600-c018-11e9-890e-f6eaa7deab01.png)
We often see teams choosing vague and/or generic names for their
namespaces, as well as for the domains for their services.

We're hoping to improve this by highlighting the issue of naming
early.