### PR TITLE
Reinstall gems after github security alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (6.7.7.2)
       execjs
-    backports (3.12.0)
+    backports (3.15.0)
     chronic (0.10.2)
     chunky_png (1.3.11)
     coderay (1.1.2)
@@ -18,7 +18,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.18.2)
+    commonmarker (0.20.1)
       ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -34,7 +34,7 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.1.5)
     contracts (0.13.0)
-    dotenv (2.7.1)
+    dotenv (2.7.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -43,8 +43,8 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.1.5)
-    ffi (1.10.0)
-    govuk_tech_docs (1.8.0)
+    ffi (1.11.1)
+    govuk_tech_docs (1.8.3)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
@@ -58,7 +58,7 @@ GEM
       openapi3_parser
       pry
       redcarpet (~> 3.3.2)
-    haml (5.0.4)
+    haml (5.1.2)
       temple (>= 0.8.0)
       tilt
     hamster (3.0.0)
@@ -73,21 +73,21 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
     method_source (0.9.2)
-    middleman (4.3.3)
+    middleman (4.3.5)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
       kramdown (~> 1.2)
-      middleman-cli (= 4.3.3)
-      middleman-core (= 4.3.3)
+      middleman-cli (= 4.3.5)
+      middleman-core (= 4.3.5)
     middleman-autoprefixer (2.7.1)
       autoprefixer-rails (>= 6.5.2, < 7.0.0)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.3.3)
+    middleman-cli (4.3.5)
       thor (>= 0.17.0, < 2.0)
     middleman-compass (4.0.1)
       compass (>= 1.0.0, < 2.0.0)
       middleman-core (>= 4.0.0)
-    middleman-core (4.3.3)
+    middleman-core (4.3.5)
       activesupport (>= 4.2, < 5.1)
       addressable (~> 2.3)
       backports (~> 3.6)
@@ -127,7 +127,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     openapi3_parser (0.5.2)
       commonmarker (~> 0.17)
@@ -137,15 +137,14 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
-    parallel (1.14.0)
+    parallel (1.17.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.3)
-    rack (2.0.6)
+    public_suffix (3.1.1)
+    rack (2.0.7)
     rack-livereload (0.3.17)
       rack
-    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -154,9 +153,8 @@ GEM
     ruby-enum (0.7.2)
       i18n
     sass (3.4.25)
-    sassc (2.0.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
-      rake
     servolux (0.13.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -180,4 +178,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   1.17.2
+   2.0.2

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 IMAGE := cloud-platform-user-guide
 DOMAIN := user-guide.cloud-platform.service.justice.gov.uk
-VERSION := 1.0
+VERSION := 1.1
 
 .built-docker-image: Dockerfile Gemfile
 	docker build -t $(IMAGE) .


### PR DESCRIPTION
> Known high severity security vulnerability detected in nokogiri < >
1.10.4 defined in Gemfile.lock.
> Gemfile.lock update suggested: nokogiri ~> 1.10.4.

This bumps nokogiri to 1.10.4