### PR TITLE
Revert the accidental switch to bundler 2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,4 +178,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   2.0.2
+   1.17.2


### PR DESCRIPTION
This causes the circleci build pipeline to fail.
This commit should fix it.