### PR TITLE
Bump the image version

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 IMAGE := cloud-platform-user-guide
 DOMAIN := user-guide.cloud-platform.service.justice.gov.uk
-VERSION := 1.1
+VERSION := 1.2
 
 .built-docker-image: Dockerfile Gemfile
 	docker build -t $(IMAGE) .


### PR DESCRIPTION
This commit is mainly here as a record that I pushed a new version
of the docker image to docker hub.

After #135, the circleci build pipeline was broken, but we didn't
notice because there haven't been any content updates since then.
Updating the image on docker hub fixed the circleci build pipeline