### PR TITLE
Change the service.yaml file to use 'https'

### DIFF
--- a/source/documentation/deploying-an-app/helloworld-app-deploy.md
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.md
@@ -32,7 +32,7 @@ This guide assumes the following:
 * Clone the [demo application](https://github.com/ministryofjustice/cloud-platform-helloworld-ruby-app)
 
 ```bash
-git clone https://github.com/ministryofjustice/cloud-platform-helloworld-ruby-app  
+git clone https://github.com/ministryofjustice/cloud-platform-helloworld-ruby-app
 cd cloud-platform-helloworld-ruby-app
 ```
 
@@ -159,7 +159,7 @@ metadata:
 spec:
   ports:
   - port: 4567
-    name: http
+    name: https
     targetPort: 4567
   selector:
     app: helloworld-rubyapp


### PR DESCRIPTION
I went through a very similar process to this, yesterday, and the
app I deployed was not accessible via the URL until I changed the
port name in the spec. from 'http' to 'https'.

I think we must have changed something about the way in which
ingresses/services work, by default, since the article was
originally written.

I haven't worked through this example, since making the change,
but I'm confident this is an issue, based on this:

https://github.com/ministryofjustice/cloud-platform-environments/pull/1181