### PR TITLE
Add a link to RDS external access documentation

### DIFF
--- a/source/documentation/other-topics/rds-external-access.md
+++ b/source/documentation/other-topics/rds-external-access.md
@@ -1,0 +1,3 @@
+### Accessing your RDS database
+
+If you need to connect from your development machine to your RDS instance, you can find instructions on how to do so [here](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance#access-outside-the-cluster)

--- a/source/tasks.html.md.erb
+++ b/source/tasks.html.md.erb
@@ -41,6 +41,7 @@ weight: 30
 <%= partial 'documentation/other-topics/index' %>
 <%= partial 'documentation/other-topics/git-crypt-setup' %>
 <%= partial 'documentation/other-topics/secrets' %>
+<%= partial 'documentation/other-topics/rds-external-access' %>
 <%= partial 'documentation/other-topics/aws-rds-migration' %>
 <%= partial 'documentation/other-topics/rds-ssl' %>
 <%= partial 'documentation/other-topics/quick-reference' %>

--- a/source/tasks.html.md.erb
+++ b/source/tasks.html.md.erb
@@ -42,6 +42,7 @@ weight: 30
 <%= partial 'documentation/other-topics/git-crypt-setup' %>
 <%= partial 'documentation/other-topics/secrets' %>
 <%= partial 'documentation/other-topics/aws-rds-migration' %>
+<%= partial 'documentation/other-topics/rds-ssl' %>
 <%= partial 'documentation/other-topics/quick-reference' %>
 <%= partial 'documentation/other-topics/cloud-platform-support' %>
 <%= partial 'documentation/other-topics/zero-downtime-deployment' %>
@@ -52,7 +53,6 @@ weight: 30
 <%= partial 'documentation/other-topics/statefulsets' %>
 <%= partial 'documentation/other-topics/decommission-unused-template-deploy-services' %>
 <%= partial 'documentation/other-topics/troubleshooting' %>
-<%= partial 'documentation/other-topics/rds-ssl' %>
 <%= partial 'documentation/other-topics/Cronjobs' %>
 <%= partial 'documentation/other-topics/TZ-Cronjobs' %>
 <%= partial 'documentation/other-topics/modsecurity' %>


### PR DESCRIPTION
Add a link from the user guide to the documentation which
explains how to use a port-forward pod to connect your
local development machine to a cluster RDS instance