### PR TITLE
Fix docker-push in makefile to use version

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,8 +7,8 @@ VERSION := 1.2
 	touch .built-docker-image
 
 docker-push: .built-docker-image
-	docker tag $(IMAGE) ministryofjustice/$(IMAGE)
-	docker push ministryofjustice/$(IMAGE)
+	docker tag $(IMAGE) ministryofjustice/$(IMAGE):$(VERSION)
+	docker push ministryofjustice/$(IMAGE):$(VERSION)
 
 server:
 	docker run \


### PR DESCRIPTION
Fix makefile, when docker-push is run use the version when tagging image.