### PR TITLE
Pin govuk_tech_docs to 1.8.3 & update Gemfile.lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     docker:
       # This docker image is created from the Dockerfile in
       # this repository.
-      - image: ministryofjustice/cloud-platform-user-guide:1.2
+      - image: ministryofjustice/cloud-platform-user-guide:1.4
         environment:
           # This is the domain on which the user guide is served
           DOMAIN: user-guide.cloud-platform.service.justice.gov.uk

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /app
 
 COPY Gemfile Gemfile.lock ./
 
+RUN gem install bundler
 RUN bundle install
 
 RUN chown -R appuser:appgroup /app

--- a/Dockerfile.gemfile-lock
+++ b/Dockerfile.gemfile-lock
@@ -1,0 +1,5 @@
+FROM ruby:2.6.2-alpine
+
+RUN apk --update add --virtual build_deps build-base
+COPY Gemfile ./
+RUN gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ ruby '2.6.2'
 
 source 'https://rubygems.org'
 
-gem 'govuk_tech_docs'
+gem 'govuk_tech_docs', '1.8.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (6.7.7.2)
       execjs
     backports (3.15.0)
@@ -42,7 +42,7 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     fast_blank (1.0.0)
-    fastimage (2.1.5)
+    fastimage (2.1.7)
     ffi (1.11.1)
     govuk_tech_docs (1.8.3)
       activesupport
@@ -125,7 +125,7 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 2.0)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.12.0)
     multi_json (1.13.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -141,7 +141,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.1.1)
+    public_suffix (4.0.1)
     rack (2.0.7)
     rack-livereload (0.3.17)
       rack
@@ -153,16 +153,16 @@ GEM
     ruby-enum (0.7.2)
       i18n
     sass (3.4.25)
-    sassc (2.1.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     servolux (0.13.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    temple (0.8.1)
+    temple (0.8.2)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -172,10 +172,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk_tech_docs
+  govuk_tech_docs (= 1.8.3)
 
 RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   1.17.2
+   2.0.2

--- a/makefile
+++ b/makefile
@@ -6,6 +6,14 @@ VERSION := 1.2
 	docker build -t $(IMAGE) .
 	touch .built-docker-image
 
+Gemfile.lock: Dockerfile.gemfile-lock
+	docker build -t temp -f Dockerfile.gemfile-lock .
+	docker run \
+		-v $$(pwd):/app \
+		-w /app \
+		-it \
+		temp bundle install
+
 docker-push: .built-docker-image
 	docker tag $(IMAGE) ministryofjustice/$(IMAGE):$(VERSION)
 	docker push ministryofjustice/$(IMAGE):$(VERSION)

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 IMAGE := cloud-platform-user-guide
 DOMAIN := user-guide.cloud-platform.service.justice.gov.uk
-VERSION := 1.2
+VERSION := 1.4  # Change this in .circleci/config.yml if you update it here
 
 .built-docker-image: Dockerfile Gemfile Gemfile.lock
 	docker build -t $(IMAGE) .

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ IMAGE := cloud-platform-user-guide
 DOMAIN := user-guide.cloud-platform.service.justice.gov.uk
 VERSION := 1.2
 
-.built-docker-image: Dockerfile Gemfile
+.built-docker-image: Dockerfile Gemfile Gemfile.lock
 	docker build -t $(IMAGE) .
 	touch .built-docker-image
 


### PR DESCRIPTION
govuk_tech_docs has been updated a lot, in the  last few weeks, with
changes that are not backwards compatible.

This commit pins us to the last known good version of the gem, until we can
upgrade the whole user guide to the latest version.