### PR TITLE
Clarify not to remove yaml files too soon, when deleting a namespace

### DIFF
--- a/source/documentation/deploying-an-app/cleaning-up.md
+++ b/source/documentation/deploying-an-app/cleaning-up.md
@@ -62,8 +62,8 @@ your namespace, after it is deleted.
 ### 4. Delete all of the kubernetes resources inside your namespace.
 
 In your working copy of your application code, you can use the kubernetes
-deployment yaml files to delete your namespace and all the kubernetes resources
-within it.
+deployment yaml files to delete all the kubernetes resources within your
+namespace.
 
 Assuming your current working directory is a working copy of your application,
 and that your kubernetes deployment yaml files are in a directory called

--- a/source/documentation/deploying-an-app/cleaning-up.md
+++ b/source/documentation/deploying-an-app/cleaning-up.md
@@ -43,20 +43,20 @@ it should manage resources for this namespace, but that there should be no
 resources, so terraform will delete any resources that do exist.
 
 Once you have deleted the other `*.tf` files from your namespace's resources
-folder, raise a [PR][] to get your changes merged. As soon as this happens, the
+folder, raise a [PR] to get your changes merged. As soon as this happens, the
 cloud platform build pipeline will run, and your AWS resources will be deleted.
 
 ### 3. Remove your namespace code from the cloud-platform-environments repository
 
 After your change to delete all the `\*.tf` files except `main.tf` has been
-merged, please raise an additional [PR][] removing the whole of your namespace code
+merged, please raise an additional [PR] removing the whole of your namespace code
 from the [cloud-platform-environments][envrepo] repository.
 
 i.e. deleting the whole of the directory:
 
      cloud-platform-environments/namespaces/live-1.cloud-platform.service.justice.gov.uk/[your namespace]
 
-Merging this [PR][] will prevent the cloud platform build pipeline from recreating
+Merging this [PR] will prevent the cloud platform build pipeline from recreating
 your namespace, after it is deleted.
 
 ### 4. Delete all of the kubernetes resources inside your namespace.
@@ -83,7 +83,7 @@ If you are using [Helm][], the equivalent command is:
 
 Deleting a namespace requires admin access to the cluster.
 
-Please raise a [PR][] against the [cloud-platform-environments][envrepo] repository,
+Please raise a [PR] against the [cloud-platform-environments][envrepo] repository,
 specifying the namespace you would like the team to delete.
 
 ### Summary

--- a/source/documentation/deploying-an-app/cleaning-up.md
+++ b/source/documentation/deploying-an-app/cleaning-up.md
@@ -48,7 +48,7 @@ cloud platform build pipeline will run, and your AWS resources will be deleted.
 
 ### 3. Remove your namespace code from the cloud-platform-environments repository
 
-After your change to delete all the `\*.tf` files except `main.tf` has been
+After your change to delete all the `*.tf` files except `main.tf` has been
 merged, please raise an additional [PR] removing the whole of your namespace code
 from the [cloud-platform-environments][envrepo] repository.
 

--- a/source/documentation/deploying-an-app/cleaning-up.md
+++ b/source/documentation/deploying-an-app/cleaning-up.md
@@ -46,6 +46,9 @@ Once you have deleted the other `*.tf` files from your namespace's resources
 folder, raise a [PR] to get your changes merged. As soon as this happens, the
 cloud platform build pipeline will run, and your AWS resources will be deleted.
 
+NB: In this PR, **do not remove** the yaml files which define your
+namespace. That must be done in a subsequent step.
+
 ### 3. Remove your namespace code from the cloud-platform-environments repository
 
 After your change to delete all the `*.tf` files except `main.tf` has been


### PR DESCRIPTION
When the user wants to delete their namespace, they must leave the yaml
files in place, in the first stage of the process. If they remove the yaml
files in their first PR, the build pipeline will fail.

Related to https://github.com/ministryofjustice/cloud-platform/issues/1343