### PR TITLE
Remove (almost) all references to live-0

### DIFF
--- a/source/documentation/deploying-an-app/add-aws-resources.md
+++ b/source/documentation/deploying-an-app/add-aws-resources.md
@@ -8,17 +8,6 @@ The documentation for the modules lives in each module's repository and you can 
 
 The updated list of terraform modules provided by the MoJ are available here: [Terraform Modules][tf-modules-list]
 
-```
-!!!  WARNING  !!!
-
-Be aware that the latest versions of these modules will only be compatible
-with Live-1.
-
-If you are planing on deploying them against Live-0, please read their
-respective READMEs carefully for instruction.
-
-```
-
 ### Usage
 
 In each terraform module repository, you will find a directory named `example` which includes sample configuration for use in Cloud Platform.

--- a/source/documentation/getting-started/kubectl-config.md
+++ b/source/documentation/getting-started/kubectl-config.md
@@ -32,7 +32,6 @@ Live clusters are those available to users:
 
 | Cluster Name | Login page |
 | ------------ | ---------- |
-| `cloud-platform-live-0` | [https://login.apps.cloud-platform-live-0.k8s.integration.dsd.io/](https://login.apps.cloud-platform-live-0.k8s.integration.dsd.io/) |
 | `live-1.cloud-platform` | [https://login.cloud-platform.service.justice.gov.uk/](https://login.cloud-platform.service.justice.gov.uk/) |
 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
@@ -88,6 +87,5 @@ Once you are ready to deploy applications you will need to create an environment
 [Kuberos]: https://github.com/negz/kuberos
 [kubeconfig]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 [multiple-clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
-[live-0-login]: https://login.apps.cloud-platform-live-0.k8s.integration.dsd.io/
 [live-1-login]: https://login.apps.live-1.cloud-platform.service.justice.gov.uk/
 [kubectl-cheatsheet]: https://kubernetes.io/docs/reference/kubectl/cheatsheet/

--- a/source/documentation/logging-an-app/access-logs.md
+++ b/source/documentation/logging-an-app/access-logs.md
@@ -13,9 +13,6 @@ To access Kibana, follow the appropriate link below and authenticate with your G
 ##### Live-1 Cluster
 [https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana)
 
-##### Live-0 Cluster
-[https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/plugin/kibana/](https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana/)
-
 #### Using Kibana
 
 As a quick example, we will filter down to the logs of a particular environment.

--- a/source/documentation/other-topics/ip-whitelisting.md
+++ b/source/documentation/other-topics/ip-whitelisting.md
@@ -45,7 +45,7 @@ Testing with the annotation set:
 ```
 curl -v -H "Host: my-app.apps.live-1.cloud-platform.service.justice.gov.uk" <HOST-IP>
 ```
-Will return a "403 forbidden" status 
+Will return a "403 forbidden" status
 
 #### Outbound IP Whitelisting
 
@@ -56,13 +56,6 @@ Many applications use third-party tools for a variety of reasons, and many of th
 The Cloud Platform uses NAT Gateways as its external IP Endpoints.
 
 The IP addresses for the clusters are as follows:
-
-###### Live-0 Cluster
-```
-52.17.133.167
-34.251.93.81
-34.247.134.240
-```
 
 ###### Live-1 Cluster
 ```

--- a/source/documentation/other-topics/live1-migration-guide.md
+++ b/source/documentation/other-topics/live1-migration-guide.md
@@ -72,12 +72,6 @@ The environment variables you will need to replace are as follows:
 
 After triggering the CircleCI pipeline, your application should now deploy into your new environment.
 
-### Deleting your Live-0 deployment
-
-The last thing you will need to do is to delete your application from the `live-0` cluster.
-
-Please see the documentation on [cleaning up within the Cloud Platform][ug-cleaning-up].
-
 ### Other considerations
 
 #### PodSecurityPolicy


### PR DESCRIPTION
We don't and won't use the live-0 cluster for anything new. This
change removes almost every reference to live-0 from the user
guide. The exception is in the section on migrating from live-0 to
live-1, which could still be relevant.