### PR TITLE
Add a note about pods being spread across nodes

### DIFF
--- a/source/documentation/deploying-an-app/helloworld-app-deploy.md
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.md
@@ -148,6 +148,8 @@ Change the image value to refer to the image you pushed to your ECR in the earli
 
 This file tells Kubernetes to run four pods (`replicas: 4`) containing a single container based on a specific docker image from your ECR. We recommend 4 replicas for most components of production services. Your application will be restarted when kubernetes moves workloads from one worker node to another, and having multiple replicas helps to ensure that your service doesn't have any downtime when this happens.
 
+By default, the scheduler will try to [spread your pods across different worker nodes][assign pods to nodes] so that if a worker node dies only a single replica should be affected, leaving the others to handle traffic while the affected pod is automatically replaced.
+
 The `strategy` section means that, when it is moved, the cluster will create a complete new copy of your application first, before it starts killing the pods on the node you're being migrated away from. More information about deployment strategies is available [here][deployment-strategies]
 
 NB: This guidance about replicas doesn't apply for things where you must only have a single instance running (e.g. a background job processor where you must process jobs in FIFO order - if you were to run mutiple instances of that, you might have problems, so a Recreate strategy, with a single replica, might be better).
@@ -375,3 +377,4 @@ Now, if you reload the browser page showing the 'Hello world' message from the a
 [decode-script]: https://github.com/ministryofjustice/cloud-platform-environments/blob/master/bin/decode.rb
 [deployment-strategies]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 [ingress-docs]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[assign pods to nodes]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
This may help to preempt requests for pod anti-affinity policies,
which seem to be unnecessary for the vast majority of our services.