### PR TITLE
Change rack from 2.0.7 to 2.0.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (4.0.1)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-livereload (0.3.17)
       rack
     rb-fsevent (0.10.3)


### PR DESCRIPTION
Fixes security advisory
https://github.com/ministryofjustice/cloud-platform-user-guide/network/alert/Gemfile.lock/rack/open