### PR TITLE
Add port-forward access instructions

### DIFF
--- a/source/documentation/other-topics/rds-external-access.html.md.erb
+++ b/source/documentation/other-topics/rds-external-access.html.md.erb
@@ -66,6 +66,8 @@ kubectl \
 
 You need to leave this running as long as you are accessing the database.
 
+> Manually-created pods (i.e. those which are not part of a [deployment]) block some cluster operations such as [draining a node] in order to replace it. For this reason, we have set up an automated process which will delete any such pods after 48 hours. If you need a port-forward pod to persist longer than this, please make it part of a [deployment].
+
 ### 3. Access the database
 
 Now you can connect to the database as if it were running locally, on your machine.
@@ -107,4 +109,4 @@ kubectl delete pod port-forward-pod -n [your namespace]
 [RDS module]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance
 [port-forward-image]: https://cloud.docker.com/u/ministryofjustice/repository/docker/ministryofjustice/port-forward
 [deployment]: https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/
-
+[draining a node]: https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#use-kubectl-drain-to-remove-a-node-from-service

--- a/source/documentation/other-topics/rds-external-access.html.md.erb
+++ b/source/documentation/other-topics/rds-external-access.html.md.erb
@@ -1,10 +1,110 @@
 ---
 title: Accessing your RDS database
-last_reviewed_on: 2019-12-09
+last_reviewed_on: 2020-01-13
 review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
 
+When you create an RDS instance using the [RDS module], it is created inside a
+virtual private cloud (VPC), which will only accept network connections from
+within the kubernetes cluster.  So, trying to connect to the RDS instance from
+your local machine will not work.
 
-If you need to connect from your development machine to your RDS instance, you can find instructions on how to do so [here](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance#access-outside-the-cluster)
+```
++--------------+                   \ /                        +--------------+
+| Your machine | -------------------X-----------------------> | RDS instance |
++--------------+                   / \                        +--------------+
+```
+
+If you need to access your database from outside the cluster (e.g. from your
+own development machine, or to perform a bulk data import), you can do so via
+the following steps:
+
+1. Run a pod inside the cluster to forward network traffic to your RDS instance
+2. Tell kubernetes to forward traffic from your local machine to the new pod
+3. Access the database as if it were running on your local machine
+
+So, the connection from your machine to the RDS instance works like this:
+
+```
++--------------+             +---------------------+          +--------------+
+| Your machine |------------>| Port forwarding pod |--------->| RDS instance |
++--------------+             +---------------------+          +--------------+
+```
+
+### 1. Run a port-forward pod
+
+There are several docker images designed to forward network traffic, but you need one which does not run as `root`. We will use [ministryofjustice/port-forward][port-forward-image] for this example.
+
+NB: **The cluster pod security policy (PSP) will prevent any images from running a process as the `root` user, so docker images which expect to do this will not work.**
+
+```
+kubectl \
+  -n [your namespace] \
+  run port-forward-pod \
+  --generator=run-pod/v1 \
+  --image=ministryofjustice/port-forward \
+  --port=5432 \
+  --env="REMOTE_HOST=[your database hostname]" \
+  --env="LOCAL_PORT=5432" \
+  --env="REMOTE_PORT=5432"
+```
+
+Note: This creates a pod in your namespace, but without a deployment to manage it. This means that, if the cluster moves your workload to a different node, the port-forward pod will not be moved - it will just disappear. If you need your port-forward pod to persist, please use a [deployment].
+
+### 2. Forward local traffic to the port-forward-pod
+
+Now you need to forward network traffic from a port on your local machine to the port-forward pod inside the cluster.
+
+```
+kubectl \
+  -n [your namespace] \
+  port-forward \
+  port-forward-pod 5432:5432
+```
+
+You need to leave this running as long as you are accessing the database.
+
+### 3. Access the database
+
+Now you can connect to the database as if it were running locally, on your machine.
+
+If you are exporting a database URL from your RDS kubernetes secret, it might have a value like this:
+
+```
+postgres://cpDvquXO5B:R1eDN0xEUnaH6Aqr@cloud-platform-df3589e0e7acba37.cdwm328dlye6.eu-west-2.rds.amazonaws.com:5432/dbdf3589e0e7acba37
+
+```
+
+You can use this URL to connect to your database via the port forward you have set up, but you need to replace the database hostname, (`cloud-platform-df3589e0e7acba37.cdwm328dlye6.eu-west-2.rds.amazonaws.com` in this example), with `localhost`.
+
+So, if you were starting from the database URL above, the database connection command you will run on your local machine would be:
+
+```
+psql postgres://cpDvquXO5B:R1eDN0xEUnaH6Aqr@localhost:5432/dbdf3589e0e7acba37
+```
+
+If you are exporting the database credentials separately, the command would be something like this:
+
+```
+psql \
+  --host localhost \
+  --port 5432 \
+  --dbname [your database name] \
+  --username [your database username] \
+  --password
+```
+
+(You will be prompted to enter the database password, which you should get (and then base64 decode) from your kubernetes secret)
+
+Please remember to delete the port-forwarding pod when you have finished.
+
+```
+kubectl delete pod port-forward-pod -n [your namespace]
+```
+
+[RDS module]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance
+[port-forward-image]: https://cloud.docker.com/u/ministryofjustice/repository/docker/ministryofjustice/port-forward
+[deployment]: https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/
+


### PR DESCRIPTION
The instructions on how to access an RDS database via a port-forwarding pod
were in the README.md file of the RDS terraform module repository.

They belong in the user guide, so this commit adds them.

Also, add a note about auto-deletion of manually-created pods.