### PR TITLE
Remove 'incident handling' from processes page

### DIFF
--- a/source/documentation/reference/operational-processes.html.md.erb
+++ b/source/documentation/reference/operational-processes.html.md.erb
@@ -7,7 +7,7 @@ review_in: 3 months
 # <%= current_page.data.title %>
 
 
-This is a record of the operational processes that we will use to support our users and to maintain the cloud platform. 
+This is a record of the operational processes that we will use to support our users and to maintain the cloud platform.
 
 ### Hours of support
 
@@ -54,9 +54,9 @@ At least one engineer to:
 
 ### `#ask-cloud-platform` slack channel
 
-The [`#ask-cloud-platform`](https://mojdt.slack.com/messages/C57UPMZLY/) channel is our main entry point for support. We encourage people to ask questions and report problems in this channel and we'll do the best we can to help. We also welcome comments, opinions and any feedback regarding any of the services and the platform as a whole. This channel can also be used to communicate to other cloud platform users on topics you think that might be useful for other users.  
+The [`#ask-cloud-platform`](https://mojdt.slack.com/messages/C57UPMZLY/) channel is our main entry point for support. We encourage people to ask questions and report problems in this channel and we'll do the best we can to help. We also welcome comments, opinions and any feedback regarding any of the services and the platform as a whole. This channel can also be used to communicate to other cloud platform users on topics you think that might be useful for other users.
 
-One of the Cloud Platform Team will be available to answer questions throughout the hours of support (10AM - 5PM).  
+One of the Cloud Platform Team will be available to answer questions throughout the hours of support (10AM - 5PM).
 
 ### What we communicate
 
@@ -95,50 +95,6 @@ As agreed with the relevant teams, the cloud platform team will be upgrading Pos
 
 >
 We will be doing this work between 10AM and 3PM, we will update at 1PM and 3PM to say how it is going.
-
-### Our incident process
-
-An incident starts when a member of the support team says that it has. It is usually triggered by an alert that indicates a problem. The team member that calls it will send a message saying that there is an incident in progress to [`#cloud-platform`](https://mojdt.slack.com/messages/C514ETYJX/) and if user impacting, [`#ask-cloud-platform`](https://mojdt.slack.com/messages/C57UPMZLY/) and [`#cloud-platform-update`](https://mojdt.slack.com/messages/CH6D099DF/)
-
-1. Support team chooses an incident lead. This person will be the main investigator of the incident. They start to work on the problem, calling on other team members (from the whole team) to help as required.
-
-2. The rest of the support team communicates the incident out to those who are impacted, including giving updates at regular intervals. People to include:
-    * Users who are affected by the problem - via [`#ask-cloud-platform`](https://mojdt.slack.com/messages/C57UPMZLY/), [`#cloud-platform-update`](https://mojdt.slack.com/messages/CH6D099DF/) and the affected team's own slack channels.
-    * Team members for awareness or as they might be able to help - via [`#cloud-platform`](https://mojdt.slack.com/messages/C514ETYJX/) and the `@cloud-platform-team` group
-    * People in the team who manage communication with senior leadership in MoJ - Steve, Karen, Tony.
-
-3. In a *high priority incident* (see below), the support team will gather every 1 hour to work out if additional people/skills are needed and update any external comms.
-
-4. Once the incident is resolved, the support team will communicate that out and prepare for a postmortem.  
-
-### Prioritising incidents
-
-An incident is a system failure or degradation that has an impact on users of the cloud platform.
-
-The size of that impact determines the priority of the incident. At the moment, we find it useful to categories incidents as high priority - we will begin work on any incident as soon as a member of the support team is available but high priority incidents require greater focus and communication.
-
-### High priority
-
-* Service outages of user facing services
-* Slowdown or degradation of service on a user facing service
-* Failure of a system that stops one or more teams from working
-* Failure of a system that creates a major vulnerability in the cloud platform
-
-### Postmortems
-
-In the cloud platform team we follow the practice of better understanding system failures through [blameless postmortems](https://codeascraft.com/2012/05/22/blameless-postmortems/).
-
-The point of a postmortem is to understand the various factors that led up to a system failure and to try to identify things that can be improved to try to stop a similar event occurring in future.
-
-Our approach to postmortems is to:
-
-* For high priority incidents to hold a group session as soon as possible after the incident is closed
-* Develop a timeline of the activities that led to the incident and its resolution
-* Walkthrough that timeline and use it to identify opportunities for improvements
-* Emerge with a prioritised list of improvements to be made, with owners
-* Write up and publish the postmortem, giving a record of the timeline and any actions that have been agreed
-
-We currently publish our postmortem reports on [pagerduty](https://moj-digital-tools.pagerduty.com/postmortems/). We have agreement to make these public and are in the process of working out how to do that.
 
 ### Our on call process
 


### PR DESCRIPTION
This is now defined in a runbook, and isn't really relevant for
the user guide anyway.

depends on https://github.com/ministryofjustice/cloud-platform/pull/1620