### PR TITLE
Fix a "broken" link

### DIFF
--- a/source/documentation/concepts/security-controls.html.md.erb
+++ b/source/documentation/concepts/security-controls.html.md.erb
@@ -38,7 +38,7 @@ infrastructure from other components in the same VPC.
 
 It is not possible to use security groups in this way in the CP.
 
-The kubernetes cluster has a pool of [worker nodes] (EC2 instances) which are
+The kubernetes cluster has a pool of [worker nodes] \(EC2 instances\) which are
 entirely interchangeable from the point of view of the services hosted in the
 cluster. Services do not know, and should not care, which worker nodes are
 hosting them at any given moment. So, network connections to for example an


### PR DESCRIPTION
The worker nodes link was being misinterpreted, because it was
immediately followed by another string in parentheses.
Adding backslashes to the parentheses stops jenkins from trying to
interpret the string as a link target.