### PR TITLE
html-proofer test to ignore canonical urls when testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run: bundle exec middleman build --build-dir docs
 
         # Test the hyperlinks
-      - run: bundle exec htmlproofer --allow-hash-href ./docs
+      - run: bundle exec htmlproofer --allow-hash-href --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" ./docs
 
         # Replace docs/.nojekyll (which gets deleted during the build process) so github knows we're
         # not using jekyll. Without this, github will try to process our files, and error.

--- a/makefile
+++ b/makefile
@@ -42,7 +42,7 @@ build: .built-docker-image
 	echo $(DOMAIN) > docs/CNAME
 
 test: 
-	bundle exec htmlproofer --allow-hash-href ./docs
+	bundle exec htmlproofer --allow-hash-href --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" ./docs
 
 # Convert the user guide to a folder-based structure
 convert:


### PR DESCRIPTION
This will swap the non existing canonical url to '' and make the test work when creating/renaming pages.
 