### PR TITLE
Remove link ref to namespace usage report webpage and add once the link is active

### DIFF
--- a/source/documentation/concepts/namespace-limits.html.md.erb
+++ b/source/documentation/concepts/namespace-limits.html.md.erb
@@ -45,7 +45,7 @@ For this reason, we need to be conservative when assigning request limits to nam
 
 ## Namespace Usage Report
 
-We publish a [web page][namespace report] showing the resources requested for each namespace, versus the resources actually used [here][namespace report]
+We publish a web page showing the resources requested for each namespace, versus the resources actually used here.
 
 ## Container request limits
 
@@ -110,4 +110,3 @@ For this reason, we're going to do ongoing work to **right-size** both new and e
 [namespace-reporter]: https://github.com/ministryofjustice/cloud-platform-environments/blob/master/bin/namespace-reporter.rb
 [prometheus]: https://prometheus.io/
 [alert-manager]: https://prometheus.io/docs/alerting/alertmanager/
-[namespace report]: https://namespace-usage-report.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/source/documentation/concepts/namespace-limits.html.md.erb
+++ b/source/documentation/concepts/namespace-limits.html.md.erb
@@ -43,10 +43,6 @@ This means it is possible to run out of cluster resources before any work is act
 
 For this reason, we need to be conservative when assigning request limits to namespaces. This won't prevent your namespace from accessing resources that it needs, but a lower request limit will help us to use the capacity of the cluster more efficiently, to run everyone's workloads.
 
-## Namespace Usage Report
-
-We publish a web page showing the resources requested for each namespace, versus the resources actually used here.
-
 ## Container request limits
 
 The smallest unit of work the cluster cares about is a container.


### PR DESCRIPTION
The htmlproofer test the circleCI pipeline fails because of the namespace usage report [url](https://namespace-usage-report.apps.live-1.cloud-platform.service.justice.gov.uk) available. 

Will be added later once the webpage is live.
