### PR TITLE
Remove hyperlink not needed. 

### DIFF
--- a/source/documentation/reference/operational-processes.html.md.erb
+++ b/source/documentation/reference/operational-processes.html.md.erb
@@ -13,7 +13,7 @@ This is a record of the operational processes that we will use to support our us
 
 Our hours of providing support are 10am - 5pm. During this time we will work on support requests from teams and make sure someone is available to answer questions in Slack channel [`#ask-cloud-platform`](https://mojdt.slack.com/messages/C57UPMZLY/) and look at PR request notifications for the cloud-platform-environments repo on [`#cloud-platform-notify`](https://mojdt.slack.com/messages/CA5MDLM34/)
 
-Outside of these hours we will respond to [high priority](#prioritising-incidents) incidents as per our [on call](#our-on-call-process) process.
+Outside of these hours we will respond to high priority incidents as per our [on call](#our-on-call-process) process.
 
 ### Working hours
 


### PR DESCRIPTION
Non exist hyperlink as part of incident handing process moved to runbook.

This is to fix circleCI test failure.
