### PR TITLE
Add heading & explanation for using secrets

### DIFF
--- a/source/documentation/deploying-an-app/add-secrets-to-deployment.html.md.erb
+++ b/source/documentation/deploying-an-app/add-secrets-to-deployment.html.md.erb
@@ -11,6 +11,8 @@ review_in: 3 months
 
 The aim of this guide is to walkthrough the process of adding a secret (in this example for aws access-key credentials) to a previously deployed application in the Cloud Platform.
 
+> This article walks you through the process of creating a secret manually. In practice, many of the secrets you will use in your applications are created automatically (e.g. database credentials).
+
 ## Prerequisites
 
 This guide assumes the following:
@@ -93,7 +95,13 @@ metadata:
   name: demosecret
 ```
 
-Add the AWS_ACCESS_KEY_ID referencing 'aws_access_key_id' and AWS_SECRET_ACCESS_KEY referencing 'aws_secret_access_key' (as previously set) to the containers env in `deployment-files/deployment.yaml`
+## Using the secret in your applications
+
+To use a secret you need to tell kubernetes to put its value in an environment variable which your application container can access. You will usually specify this in your application's `deployment.yaml` file.
+
+The following example sets an `AWS_ACCESS_KEY_ID` environment variable in the environment of the `django-demo-container`.
+
+The value of `AWS_ACCESS_KEY_ID` comes from the secret called `demosecret` which is a hash with a key called `aws_access_key_id`, and the value of that key will be the value of the environment variable `AWS_ACCESS_KEY_ID`.
 
 ```Yaml
     spec:
@@ -114,6 +122,8 @@ Add the AWS_ACCESS_KEY_ID referencing 'aws_access_key_id' and AWS_SECRET_ACCESS_
                   name: demosecret
                   key: aws_secret_access_key
 ```
+
+> When you reference a secret in this way, kubernetes takes care of the base64-decoding for you - you don't need to base64-decode the value in your code.
 
 [env-create]: /documentation/getting-started/env-create.html#creating-a-cloud-platform-environment
 [deploy-hello-world]: /documentation/deploying-an-app/helloworld-app-deploy.html#deploying-a-39-hello-world-39-application-to-the-cloud-platform


### PR DESCRIPTION

![Screen Shot 2020-02-19 at 16 21 39](https://user-images.githubusercontent.com/2338/74853117-60c33780-5335-11ea-94a5-b61b7f150161.png)
This commit provides a more verbose description of how an application
running in the CP can access data stored in a kubernetes secret.

It also adds a note emphasising that much of the time, the secrets used
by an application will be created automatically (by our terraform
modules).