### PR TITLE
Fix the `git push` step

### DIFF
--- a/bin/publish.rb
+++ b/bin/publish.rb
@@ -65,9 +65,15 @@ end
 
 def commit_and_push_docs
   set_git_credentials
-	execute %[git add docs -f]
-	execute %[git commit -m 'Publish compiled site via github action']
-	execute %[git push origin master --force]
+
+  execute %[git add docs -f]
+  execute %[git commit -m 'Publish compiled site via github action']
+
+  token = ENV.fetch("GITHUB_TOKEN")
+  actor = ENV.fetch("GITHUB_ACTOR")
+  repo = ENV.fetch("GITHUB_REPOSITORY")
+
+  execute %[git push "#{remote_repo}" HEAD:master --force]
 end
 
 def set_git_credentials


### PR DESCRIPTION
Force-pushing changes to the master branch was failing with:

    error: src refspec master does not match any.

This indicates that git didn't have an 'origin' set for the master
branch.

This commit is inspired by https://github.com/ad-m/github-push-action
and explicitly sets the remote within the git push command, to work
around this problem.