### PR TITLE
Push compiled docs files into the branch PR, not master

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -2,10 +2,7 @@ name: Publish
 
 on:
   pull_request:
-    types: [closed]
-    # This will trigger the action even if the PR is closed without merging,
-    # but in that event the action will fail when it tries to push no changes,
-    # so that probably doesn't matter.
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   publish:

--- a/bin/github.rb
+++ b/bin/github.rb
@@ -64,7 +64,7 @@ class GithubClient
   private
 
   def modified_files
-    stdout, _stderr, _status = executor.execute("git status --porcelain=1 --untracked-files=no")
+    stdout, _stderr, _status = executor.execute("git status --porcelain=1")
 
     stdout
       .split("\n")

--- a/bin/publish.rb
+++ b/bin/publish.rb
@@ -44,16 +44,6 @@ def should_rebuild?
   rtn
 end
 
-def this_commit
-  commit, _stderr, _status = execute %[git rev-parse HEAD]
-  commit
-end
-
-def files_in(commit)
-  files, _stderr, _status = execute %[git diff-tree --no-commit-id --name-only -r #{commit}]
-  files.split("\n")
-end
-
 def compile_docs_folder
   execute "bundle exec middleman build --build-dir docs"
 end

--- a/bin/publish.rb
+++ b/bin/publish.rb
@@ -10,38 +10,12 @@ require File.join(".", File.dirname(__FILE__), "github")
 DOMAIN = "user-guide.cloud-platform.service.justice.gov.uk"
 
 def main
-  if should_rebuild?
-    compile_docs_folder
-    if passes_html_proofer?
-      execute "touch docs/.nojekyll"
-      execute "echo #{DOMAIN} > docs/CNAME"
-      commit_and_push_docs
-    end
+  compile_docs_folder
+  if passes_html_proofer?
+    execute "touch docs/.nojekyll"
+    execute "echo #{DOMAIN} > docs/CNAME"
+    GithubClient.new.commit_changes("Commit compiled docs files")
   end
-end
-
-# This script was previously invoked in response to a 'git push', but
-# publishing also does a git push. So, we check here whether the current change
-# only affects compiled doc/ files. If that's true, we don't want to do
-# anything else.
-#
-# The logic here may not be needed, since the github action will only trigger
-# when a PR is closed. Since publishing the site pushes straight to the master
-# branch, without generating a PR, that should be enough to avoid an infinite
-# loop, even without this test. Still, it doesn't do any harm, so I'm leaving
-# it in.
-def should_rebuild?
-  files = GithubClient.new.files_in_pr
-
-  rtn = false
-
-  if files.any?
-    rtn = files.reject { |f| f =~ /^docs/ }.any?
-  else
-    puts "Commit changed no files (merge commit?). Proceeding with build."
-  end
-
-  rtn
 end
 
 def compile_docs_folder
@@ -51,27 +25,6 @@ end
 def passes_html_proofer?
   _stdout, _stderr, status = execute %[bundle exec htmlproofer ./docs --allow-hash-href --url-swap "https?\\:\\/\\/user-guide\\.cloud-platform\\.service\\.justice\\.gov\\.uk:" ./docs]
   status.success?
-end
-
-def commit_and_push_docs
-  set_git_credentials
-
-  execute %[git add docs -f]
-  execute %[git commit -m 'Publish compiled site via github action']
-
-  token = ENV.fetch("GITHUB_TOKEN")
-  actor = ENV.fetch("GITHUB_ACTOR")
-  repo = ENV.fetch("GITHUB_REPOSITORY")
-
-  remote_repo="https://#{actor}:#{token}@github.com/#{repo}.git"
-
-  execute %[git push "#{remote_repo}" HEAD:master --force]
-end
-
-def set_git_credentials
-	execute %[git config credential.helper cache]
-	execute %[git config user.email "platforms+githubuser@digital.justice.gov.uk"]
-	execute %[git config user.name "MoJ Cloud Platform Team Machine User"]
 end
 
 def execute(cmd)


### PR DESCRIPTION
By compiling the docs files and adding them to the PR branch, we avoid the need
to remove branch protection from the master branch of the user guide repo.