### PR TITLE
Fix "View Source" to link to "main" branch

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -39,3 +39,4 @@ prevent_indexing: true
 
 show_contribution_banner: true
 github_repo: ministryofjustice/cloud-platform-user-guide
+github_branch: main


### PR DESCRIPTION
The "View Source" links at the foot of each page link to the "master"
branch by default, so they are all currently broken. This change fixes
that by specifying "main" as the target branch for those links.