### PR TITLE
Add specific kubectl client version statement

### DIFF
--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to use `kubectl` to connect to the cluster
-last_reviewed_on: 2020-04-28
+last_reviewed_on: 2020-07-09
 review_in: 3 months
 ---
 
@@ -15,6 +15,10 @@ After working through this guide you should be able to use kubectl to query and 
 ## Installation
 
 Please read the [official documentation][kubectl-install] on how to install `kubectl`.
+
+### Before you begin
+
+You must use a kubectl version that is within one minor version difference of your cluster. For example, a v1.15 client should work with v1.41, v1.15, and v1.16 master. Using the latest version of kubectl helps avoid unforeseen issues.
 
 ## Authentication
 


### PR DESCRIPTION
Add specific kubectl client version statement to make aware that being too far ahead or behind on the client version can cause issues querying the Kubernetes API