### PR TITLE
Fix a broken Markdown reference-style link

### DIFF
--- a/source/documentation/other-topics/apiversion-changes-k8s-1-16.html.md.erb
+++ b/source/documentation/other-topics/apiversion-changes-k8s-1-16.html.md.erb
@@ -269,4 +269,4 @@ After updating your manifests to use the latest API versions, if you have any Se
 If you have any questions, please contact us on the [#ask-cloud-platform] Slack channel.
 
 [#ask-cloud-platform]: https://mojdt.slack.com/messages/C57UPMZLY
-[circleci-sa][https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html#creating-a-service-account-for-circleci]
+[circleci-sa]: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html#creating-a-service-account-for-circleci


### PR DESCRIPTION
The link was formatted incorrectly, so it wasn't displaying properly on the page.