### PR TITLE
Fix the user guide publishing process

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # Check for internal and external broken links
-bundle exec htmlproofer ./docs --http-status-ignore 429 --allow-hash-href --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" ./docs
+bundle exec htmlproofer ./docs --http-status-ignore 0,429 --allow-hash-href --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" ./docs
 
 # PUBLISHING_GIT_TOKEN is a secret in the source repository. It should contain a github personal access token
 # with `public_repo` scope, and MoJ SSO enabled.

--- a/source/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html.md.erb
+++ b/source/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html.md.erb
@@ -29,7 +29,7 @@ It is assumed you have the following:
 ### Creating a Service Account for CircleCI
 As part of the CircleCI deployment pipeline, CircleCI will need to authenticate with the Kubernetes cluster. In order to do so, Kubernetes uses [Service Accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/). Service Accounts provide an identity for processes that run in a cluster allowing the process to access the API server.
 
-A Service Account is created in the [namespace creation github repository](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces).
+A Service Account is created in the [namespace creation github repository](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces).
 
 If you have not created a CircleCI service account along with the role / rolebinding then you may
 use the below as an example:
@@ -56,7 +56,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
-      - "jobs"	
+      - "jobs"
     verbs:
       - "patch"
       - "get"
@@ -93,7 +93,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-Remember to replace `<YOUR-NAMESPACE>` with your namespace. Save the above as 'serviceaccount-circleci.yaml' under your [namespace folder](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces).
+Remember to replace `<YOUR-NAMESPACE>` with your namespace. Save the above as 'serviceaccount-circleci.yaml' under your [namespace folder](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces).
 
 Raise a PR for your service account creation. Once approved you should then see your new CircleCI service account in your namespace.
 

--- a/source/documentation/getting-started/ecr-setup.html.md.erb
+++ b/source/documentation/getting-started/ecr-setup.html.md.erb
@@ -36,7 +36,7 @@ $ cd resources
 $ vi ecr.tf
 ```
 
-4. Adapt the definition from the example described in the [cloud-platform-terraform-ecr-credentials module](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/tree/master/examples); make sure you adjust the values of `team_name`, `repo_name` `name` and `namespace` to what is appropriate for your environment.
+4. Adapt the definition from the example described in the [cloud-platform-terraform-ecr-credentials module](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/tree/main/examples); make sure you adjust the values of `team_name`, `repo_name` `name` and `namespace` to what is appropriate for your environment.
 
 
 5. git add, commit and push to your branch.

--- a/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.html.md.erb
+++ b/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.html.md.erb
@@ -17,7 +17,7 @@ This guide assumes the following:
 * You have a slack channel to send alerts to
 
 ## Create a Pingdom check
-To create a Pingdom check simply add a `pingdom.tf` file in the resources directory of your namespace in your [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces/live-1.cloud-platform.service.justice.gov.uk) repository. You can define the conditions of your check using the resources outlined in the [Terraform community provider](https://github.com/russellcardullo/terraform-provider-pingdom). Here's a working example of a [basic check](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/resources).
+To create a Pingdom check simply add a `pingdom.tf` file in the resources directory of your namespace in your [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live-1.cloud-platform.service.justice.gov.uk) repository. You can define the conditions of your check using the resources outlined in the [Terraform community provider](https://github.com/russellcardullo/terraform-provider-pingdom). Here's a working example of a [basic check](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/resources).
 
 ```yaml
 provider "pingdom" {

--- a/source/documentation/other-topics/access-cross-aws-resources.html.md.erb
+++ b/source/documentation/other-topics/access-cross-aws-resources.html.md.erb
@@ -6,8 +6,8 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
- This article explains how to use IAM role to connect and authorize from applications running in Cloud platform to 
- access AWS resources in a different AWS account. 
+ This article explains how to use IAM role to connect and authorize from applications running in Cloud platform to
+ access AWS resources in a different AWS account.
 
  Cloud Platform Infrastructure uses [KIAM](https://github.com/uswitch/kiam) to allow secured access to AWS APIs by associating IAM roles to Pods.
  By annotating the pod and the respective namespace, you can allow the application to assume a role and can get temporary credentials to access AWS resources.
@@ -15,8 +15,8 @@ review_in: 3 months
  To acheive this, follow the steps below:
 
 1. **Create IAM role**
- 
-    Cloud Platform maintain these cross account roles in [cloud-platform-infrastructure](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cross-account-IAM) repo.
+
+    Cloud Platform maintain these cross account roles in [cloud-platform-infrastructure](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cross-account-IAM) repo.
 
     Create a file (<namespace>.tf), update the below template with correct values and raise a PR.
 
@@ -184,7 +184,7 @@ review_in: 3 months
 
     Once the PR in **step 1** is merged and applied, you will get the role ARN, name and id as a kubernetes secret in your namespace.
 
-    Decode the role ARN and annotate the pod to indicate which role which will need access to resource in different AWS account. 
+    Decode the role ARN and annotate the pod to indicate which role which will need access to resource in different AWS account.
     A deployment with the Pod template annotated would look like below:
 
     ```
@@ -248,9 +248,9 @@ review_in: 3 months
 
 3. **Annotate the namespace to allow the role to AssumeRole**
 
-    Next, annotate the namespace to indicate which roles are permitted to be assumed within the namespace. 
-    
-    Update the `annotations` section with the below code along with existing annotations list in `00-namespace.yaml` 
+    Next, annotate the namespace to indicate which roles are permitted to be assumed within the namespace.
+
+    Update the `annotations` section with the below code along with existing annotations list in `00-namespace.yaml`
     for your namespace in the (cloud-platform-environments)[] repo and raise a PR.
 
     ```
@@ -290,27 +290,27 @@ review_in: 3 months
 
 4. **Use the IAM role in your application**
 
-    There are several ways you can use the role created to access the resource in different AWS account. 
-    
+    There are several ways you can use the role created to access the resource in different AWS account.
+
     An example to call the AWS SDK for Ruby and get temporary AWS credentials as below:
 
     ```
     role_credentials = Aws::AssumeRoleCredentials.new(
       role_arn: role_arn,
       role_session_name: "myapp_session"
-    ) 
+    )
     ```
-   
+
     The above call will return the `role_credentials` with a hash which consist of an access key ID, a secret access key, and a security token.
 
-    For more details on using assumeRole check AWS documentation for [AWS assume-role CLI](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html) 
+    For more details on using assumeRole check AWS documentation for [AWS assume-role CLI](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html)
     and [AW::AssumeRoleCredentials SDK](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/AssumeRoleCredentials.html)
 
 
 5. **Allow the IAM role to permit access in the target AWS account**
-   
+
     You also need to update the AWS resource policy of the target AWS account to allow permissions for the IAM role to perform actions.
-    
+
     An example s3 bucket policy to allow the IAM role to perform specific actions as below:
 
     ```


### PR DESCRIPTION
* Ignore http response code 0 (fixes a 'broken' external link)
* Link to 'main' branch of our github repos (not sure why this worked before)