### PR TITLE
Patch the gov.uk tech-docs gems after installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,10 @@ WORKDIR /app
 COPY Gemfile Gemfile.lock ./
 
 RUN bundle install
+
+# patch the installed gems
+# see: https://github.com/alphagov/tech-docs-gem/issues/191
+COPY gem-patches/*.patch /tmp/
+RUN patch /usr/local/bundle/gems/middleman-search-gds-0.11.1/lib/middleman-search/search-index-resource.rb -i /tmp/search-index-resource.rb.patch
+RUN patch /usr/local/bundle/gems/govuk_tech_docs-2.0.12/lib/assets/javascripts/_modules/search.js -i /tmp/search.js.patch
+RUN mv /usr/local/bundle/gems/govuk_tech_docs-2.0.12/lib/assets/javascripts/_modules/search.js /usr/local/bundle/gems/govuk_tech_docs-2.0.12/lib/assets/javascripts/_modules/search.js.erb

--- a/gem-patches/README.md
+++ b/gem-patches/README.md
@@ -1,0 +1,32 @@
+# Patches for gov.uk tech-docs gems
+
+These files represent the patches described in this issue:
+https://github.com/alphagov/tech-docs-gem/issues/191
+
+They enable using (a patched version of) the gov.uk tech-docs gem to publish a
+documentation site using github pages without requiring the site to be
+published at the root docpath ("/") of a dedicated domain.
+
+i.e. this enables publishing a site at:
+
+```
+https://username.github.io/my-repo
+```
+
+This is the default github pages URL for the repository "my-repo" belonging to
+the github user/organisation "username".
+
+As opposed to:
+
+```
+https://my.custom.domain/
+```
+
+Without these patches, the search function of the site will not work correctly.
+
+The patch files in this directory are used in the Dockerfile to build the
+docker image which is used in the publishing process.
+
+This is a nasty hack, but the alternative is to maintain forks of two gems,
+`govuk_tech_docs` and `middleman-search-gds`, so this seems a pragmatic
+solution until the issue above is resolved in the upstream gems.

--- a/gem-patches/search-index-resource.rb.patch
+++ b/gem-patches/search-index-resource.rb.patch
@@ -1,0 +1,10 @@
++++ /usr/local/bundle/gems/middleman-search-gds-0.11.1/lib/middleman-search/search-index-resource.rb
+@@ -111,6 +111,8 @@
+           end
+         end
+
++        store.each { |id, item| item[:url].sub!(/^/, ENV["ROOT_DOCPATH"].to_s) }
++
+         # Generate JSON output
+         context = ExecJS.compile(source.join("\n"))
+         json = context.eval('lunr.middlemanSearchIndex.indexJson()')

--- a/gem-patches/search.js.patch
+++ b/gem-patches/search.js.patch
@@ -1,0 +1,10 @@
++++ /usr/local/bundle/gems/govuk_tech_docs-2.0.12/lib/assets/javascripts/_modules/search.js
+@@ -34,7 +34,7 @@
+     this.downloadSearchIndex = function downloadSearchIndex () {
+       updateTitle('Loading search index')
+       $.ajax({
+-        url: '/search.json',
++        url: '<%= ENV["ROOT_DOCPATH"] %>/search.json',
+         cache: true,
+         method: 'GET',
+         success: function (data) {


### PR DESCRIPTION
These files represent the patches described in this issue:
https://github.com/alphagov/tech-docs-gem/issues/191

They enable using (a patched version of) the gov.uk tech-docs gem to publish a
documentation site using github pages without requiring the site to be
published at the root docpath ("/") of a dedicated domain.

i.e. this enables publishing a site at:

```
https://username.github.io/my-repo
```

This is the default github pages URL for the repository "my-repo" belonging to
the github user/organisation "username".

As opposed to:

```
https://my.custom.domain/
```

Without these patches, the search function of the site will not work correctly.

The patch files in this directory are used in the Dockerfile to build the
docker image which is used in the publishing process.

This is a nasty hack, but the alternative is to maintain forks of two gems,
`govuk_tech_docs` and `middleman-search-gds`, so this seems a pragmatic
solution until the issue above is resolved in the upstream gems.