### PR TITLE
Link to the CLI on the main page of the site

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -15,6 +15,7 @@ deploy and manage their applications on that infrastructure.
 
 ##Quickstart
 - [Overview of the Cloud Platform](documentation/concepts/cp-overview.html)
+- [The Cloud Platform CLI](documentation/getting-started/cloud-platform-cli.html)
 - [Deploy your first Hello World application](documentation/deploying-an-app/helloworld-app-deploy.html)
 
 ## How-to guides


### PR DESCRIPTION
This change adds a link to our existing page about the CLI, to the
homepage of the user guide.