### PR TITLE
Fix links broken reorganising technical-guidance

### DIFF
--- a/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
@@ -379,7 +379,7 @@ service "rubyapp-service" unchanged
 
 Now, if you reload the browser page showing the 'Hello world' message from the application, you will be prompted to enter the username and password.
 
-[guidance for domain names]: https://ministryofjustice.github.io/technical-guidance/standards/naming-domains/#justicegovuk
+[guidance for domain names]: https://ministryofjustice.github.io/technical-guidance/documentation/standards/naming-domains.html
 [http basic authentication]: https://en.wikipedia.org/wiki/Basic_access_authentication
 [kubernetes secret]: https://kubernetes.io/docs/concepts/configuration/secret/
 [htpasswd]: https://httpd.apache.org/docs/2.4/programs/htpasswd.html

--- a/source/documentation/getting-started/env-create.html.md.erb
+++ b/source/documentation/getting-started/env-create.html.md.erb
@@ -14,7 +14,7 @@ This is a guide to creating a environment (i.e. a `namespace`) on our Kubernetes
 We define an environment as a Kubernetes [namespace]
 with some key resources deployed in it. Each Kubernetes namespace creates a
 logical separation within our cluster that provides isolation from any other
-namespace. You can think of a namespace as a separate portion of the cloud platform 
+namespace. You can think of a namespace as a separate portion of the cloud platform
 set aside for your service.
 
 Once you have created an environment you will be able to perform actions using
@@ -286,7 +286,7 @@ spec:
 [ecr-setup]: /documentation/getting-started/ecr-setup.html#creating-an-ecr-repository
 [create-rds]: /documentation/deploying-an-app/multicontainer-app-deploy.html#create-an-rds-instance
 [namespace limits]: /documentation/concepts/namespace-limits.html#namespace-container-resource-limits
-[naming-things-guidance]: https://ministryofjustice.github.io/technical-guidance/standards/naming-things/#naming-things
+[naming-things-guidance]: https://ministryofjustice.github.io/technical-guidance/documentation/standards/naming-things.html
 [namespace]: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 [env-repo]: https://github.com/ministryofjustice/cloud-platform-environments
 [NetworkPolicy]: https://kubernetes.io/docs/concepts/services-networking/network-policies/

--- a/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.html.md.erb
+++ b/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.html.md.erb
@@ -47,7 +47,7 @@ This basic check simply checks that the host/url (in this case; uat.claim-crimin
 
 [This](https://github.com/russellcardullo/terraform-provider-pingdom#pingdom-check) page explains all the attributes used in the check.
 
-All resources, including Pingdom checks **must** be tagged and adhere to the technical guidance outlined [here](https://github.com/ministryofjustice/technical-guidance/blob/master/standards/documenting-infrastructure-owners.md). Ensure your check has appropriate tags before submitting a pull request.
+All resources, including Pingdom checks **must** be tagged and adhere to the technical guidance outlined [here](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html). Ensure your check has appropriate tags before submitting a pull request.
 
 Once reviewed and merged to master, the pipeline will create your check in the MoJ Pingdom account.
 

--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -157,7 +157,7 @@ speed up the process. You should search online for the proper method to do so,
 based on your operating system and/or browser.
 
 [env-repo]: https://github.com/ministryofjustice/cloud-platform-environments/
-[naming-domains]: https://ministryofjustice.github.io/technical-guidance/standards/naming-domains/#naming-domains
+[naming-domains]: https://ministryofjustice.github.io/technical-guidance/documentation/standards/naming-domains.html
 [creating-zone]: /documentation/other-topics/route53-zone.html#creating-a-route-53-hosted-zone
 [support-ticket]: http://goo.gl/msfGiS
 [wiki-domain-structure]: https://en.wikipedia.org/wiki/Domain_Name_System#Structure


### PR DESCRIPTION
The technical-guidance site has been restructured such that pages now
need `/documentation` inserted into the link URL, and `.html` at the end.