### PR TITLE
Use publisher docker image 1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/cloud-platform-tech-docs-publisher:1.0
+      image: ministryofjustice/cloud-platform-tech-docs-publisher:1.1
     steps:
     - uses: actions/checkout@v2
     - name: Build


### PR DESCRIPTION
This change should make no difference at all, since this github action does not set a "ROOT_DOCPATH" env. var (which is what the 1.1 image version uses to publish sites differently if they are not hosted at the root of a domain).

I'm making this change solely to keep the image versions consistent across our documentation sites, and to confirm that there really is no impact from making this change.