### PR TITLE
Only run publish workflow if source changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "source/**"
 
 jobs:
   run:


### PR DESCRIPTION
This change prevents the publish github action from running unless files below source/ have been changed.

This avoids github action failures occurring when changes are merged which do not affect the content of the user guide.