### PR TITLE
Update kramdown gem to 2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)


### PR DESCRIPTION
This fixes
https://github.com/ministryofjustice/cloud-platform/network/alert/runbooks/Gemfile.lock/kramdown/open

This change doesn't actually make any difference to this project,
because it's published using the
ministryofjustice/cloud-platform-tech-docs-publisher docker image. But,
it doesn't do any harm, and it should silence the dependabot alert.