### PR TITLE
Revert "Update kramdown gem to 2.3.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    kramdown (2.3.0)
+    kramdown (1.17.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-user-guide#409

I thought this wouldn't have any effect, but in fact it breaks the publishing process

```
Run bundle exec middleman build --build-dir docs
bundler: failed to load command: middleman (/usr/local/bundle/bin/middleman)
Bundler::GemNotFound: Could not find kramdown-2.3.0 in any of the sources
```