### PR TITLE
Fix broken links

### DIFF
--- a/source/documentation/concepts/official-sensitive.html.md.erb
+++ b/source/documentation/concepts/official-sensitive.html.md.erb
@@ -15,4 +15,4 @@ So, in principle, there is no objection to such services being hosted on the Clo
 
 If you need more formal assurance that your service can be hosted on the Cloud Platform, or you have concerns about the handling of specific kinds of data, please contact the security team via `#security` on Slack, or by emailing `cyberconsultancy@digital.justice.gov.uk`
 
-[official-sensitive]: https://ministryofjustice.github.io/security-guidance/security_decisions/mythbusting/official-official-sensitive
+[official-sensitive]: https://ministryofjustice.github.io/security-guidance/official-official-sensitive

--- a/source/documentation/other-topics/ip-filtering.html.md.erb
+++ b/source/documentation/other-topics/ip-filtering.html.md.erb
@@ -92,4 +92,4 @@ However, in the event of a catastrophic failure where we have to rebuild the pla
 
 
 [support ticket]: http://goo.gl/msfGiS
-[networks-are-bearers]: https://ministryofjustice.github.io/security-guidance/security_decisions/mythbusting/internet-v-psn
+[networks-are-bearers]: https://ministryofjustice.github.io/security-guidance/internet-v-psn/


### PR DESCRIPTION
It looks as if the security guidance site has been reshuffled a bit, and
two of our links to it got broken. This change fixes them.