### PR TITLE
Add a makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,13 @@ using [GitHub Pages][gh-pages].
 Preview changes locally by running this command:
 
 ```bash
-bundle exec middleman server
+make preview
 ```
 
 This will run a preview web server on http://localhost:4567
 
 This is only accessible on your computer, and won't be accessible
-to anyone else. It's also set up to automatically update when we
-make changes to the source files.
+to anyone else.
 
 ## Making changes
 
@@ -68,6 +67,15 @@ the user guide website.
 
 The github action is defined in `.github/workflows/publish.yml`
 
+## Link-checking
+
+The publishing process automatically checks both internal and external links in
+the site. If you want to do the same check locally, run:
+
+```
+make check
+```
+
 ## Updating the docker image
 
 If you need to make any changes to the docker image (i.e. if you make any
@@ -75,7 +83,8 @@ changes to the Dockerfile or Gemfile), please use the github web interface to
 create a new [release]. A github action will build the docker image and push
 it to docker hub, tagged with the release number.
 
-After changing the tag, you need to update the reference to the image in `.github/workflows/publish.yml`
+After changing the tag, you need to update the reference to the image in
+`.github/workflows/publish.yml` and the `makefile`.
 
 [branch protection]: https://help.github.com/articles/about-protected-branches/
 [tech-docs-multipage]: https://tdt-documentation.london.cloudapps.digital/multipage.html#repo-folder-structure

--- a/makefile
+++ b/makefile
@@ -1,0 +1,44 @@
+PUBLISHING_IMAGE := ministryofjustice/cloud-platform-tech-docs-publisher:1.1
+
+# Use this to run a local instance of the documentation site, while editing
+.PHONY: preview
+preview:
+	docker run --rm \
+		-v $$(pwd)/config.rb:/app/config.rb \
+		-v $$(pwd)/config:/app/config \
+		-v $$(pwd)/source:/app/source \
+		-p 4567:4567 \
+		$(PUBLISHING_IMAGE) \
+		bundle exec middleman serve
+
+# Build the HTML files and run the broken link checker
+.PHONY: check
+check:
+	make build
+	make htmlproofer
+
+# Build the docs/ files locally
+.PHONY: build
+build:
+	docker run --rm \
+		-v $$(pwd)/config.rb:/app/config.rb \
+		-v $$(pwd)/config:/app/config \
+		-v $$(pwd)/source:/app/source \
+		-v $$(pwd)/docs:/app/docs \
+		-p 4567:4567 \
+		$(PUBLISHING_IMAGE) \
+		bundle exec middleman build --build-dir docs 2>&1 | grep -v 'warning: URI.*escape is obsolete'
+
+# Check for broken links (assumes `make build` has been run)
+.PHONY: htmlproofer
+htmlproofer:
+	docker run --rm \
+		-v $$(pwd)/config.rb:/app/config.rb \
+		-v $$(pwd)/config:/app/config \
+		-v $$(pwd)/source:/app/source \
+		-v $$(pwd)/docs:/app/docs \
+		-p 4567:4567 \
+		$(PUBLISHING_IMAGE) \
+		bundle exec htmlproofer ./docs --http-status-ignore 429 --allow-hash-href --http-status-ignore 0,429 --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" ./docs
+
+


### PR DESCRIPTION
This allows previewing (while editing), and running the link checker
locally, using the same docker image as the github action-based
publishing process.