### PR TITLE
Add a note not to remove TD migration page.

### DIFF
--- a/source/documentation/concepts/migrate-from-td.html.md.erb
+++ b/source/documentation/concepts/migrate-from-td.html.md.erb
@@ -8,6 +8,8 @@ review_in: 3 months
 
 These are some of the things to think about when migrating your application from [Template Deploy][template-deploy] (TD) to the [Cloud Platform][cloud-platform] (CP).
 
+> Note to maintainers: This page is sometimes referenced for general migration advice. When we remove template deploy-specific pages, content on this page should be replaced by a generic migration advice page, and this page should link to that one, so that anyone following an old link can still find the information they need.
+
 ## Production infrastructure
 
 Any infrastructure resources, such as databases or cache servers, should be of the same size, and running the same software (e.g. postgres) version, for the CP version of your app. as for the TD version.


### PR DESCRIPTION
This page is sometimes referenced for general migration advice. When we remove template deploy-specific pages, content on this page should be replaced by a generic migration advice page, and this page should link to that one, so that anyone following an old link can still find the information they need.