### PR TITLE
Use a force-push to the publishing repo

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -28,6 +28,6 @@ git config --global user.email "${GITHUB_PAGES_REPO_AUTHOR_EMAIL}"
 git config --global user.name "${GITHUB_PAGES_REPO_AUTHOR}"
 git add .
 git commit -m "Published at $(date)"
-git push
+git push --force
 
 echo "Publishing complete"


### PR DESCRIPTION
The publishing action failed this morning because of a problem pushing to the gh-pages branch of the publishing repo. I'm not sure what the exact details of the problem are, but I'm hoping that using a force-push will workaround the issue.