### PR TITLE
Add "About" page (product description)

### DIFF
--- a/source/documentation/concepts/about-the-cloud-platform.md.erb
+++ b/source/documentation/concepts/about-the-cloud-platform.md.erb
@@ -1,0 +1,19 @@
+---
+title: About the Cloud Platform
+last_reviewed_on: 2020-08-26
+review_in: 3 months
+---
+
+The MoJ Cloud Platform is a modern hosting platform for digital services:
+
+- It makes it quick and easy to 'just deploy an app'
+- Teams get the features they need to operate their service, such as
+  easy scalability, zero downtime deploys, security scanning,
+  monitoring, logging, and more, all setup for you by default
+- When you need the full power of AWS or Kubernetes, it's all available
+- Configuration is all self-service, using Infrastructure as Code with
+  managed CI/CD and GitOps processes
+- The Cloud Platform team manage the hosting and provide support for
+  the platform
+
+For guidance on all MoJ hosting options, see [MoJ Technical Guidance: Hosting](https://ministryofjustice.github.io/technical-guidance/documentation/standards/hosting.html)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -11,9 +11,10 @@ review_in: 3 months
 This user guide is for service teams with applications deployed, or intending
 to deploy, to the Ministry of Justice Cloud Platform. The platform manages the
 infrastructure that your application runs on and provides tooling for teams to
-deploy and manage their applications on that infrastructure.
+deploy and manage their applications on that infrastructure. See also: [About
+the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
 
-##Quickstart
+## Quickstart
 - [Overview of the Cloud Platform](documentation/concepts/cp-overview.html)
 - [The Cloud Platform CLI](documentation/getting-started/cloud-platform-cli.html)
 - [Deploy your first Hello World application](documentation/deploying-an-app/helloworld-app-deploy.html)


### PR DESCRIPTION
We should probably describe our product offering somewhere, to help people who are trying to understand the aims and values of Cloud Platform, whether they should select it and whether there are other options.

These words come from: https://github.com/ministryofjustice/technical-guidance/pull/95/files#diff-43f7c05800f6d985dc316a108f3785b8 I think it's arguable to duplicate them.

Is this User Guide the best place? It's pretty sharply "get the tech task done" focused currently, so maybe there is a better place? But the User Guide seems most like a home page for the platform.