### PR TITLE
Remove link to the new About page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -11,8 +11,7 @@ review_in: 3 months
 This user guide is for service teams with applications deployed, or intending
 to deploy, to the Ministry of Justice Cloud Platform. The platform manages the
 infrastructure that your application runs on and provides tooling for teams to
-deploy and manage their applications on that infrastructure. See also: [About
-the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
+deploy and manage their applications on that infrastructure.
 
 ## Quickstart
 - [Overview of the Cloud Platform](documentation/concepts/cp-overview.html)


### PR DESCRIPTION
related to #435

That PR added a new page, and a link to it on the index page, in a
single PR. This is a perfectly sensible thing to do, but unfortunately
it means that the link-checker fails because the home page has a link to
a page that the link-checker doesn't know exists yet.

This is a bug, and should be fixed, but in the meantime I'm raising 2
PRs to get this change deployed successfully - one to add the new page,
and then a second to add the link to the page. That should keep the
link-checker happy.
