### PR TITLE
Replace link to the About page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -11,7 +11,8 @@ review_in: 3 months
 This user guide is for service teams with applications deployed, or intending
 to deploy, to the Ministry of Justice Cloud Platform. The platform manages the
 infrastructure that your application runs on and provides tooling for teams to
-deploy and manage their applications on that infrastructure.
+deploy and manage their applications on that infrastructure. See also: [About
+the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
 
 ## Quickstart
 - [Overview of the Cloud Platform](documentation/concepts/cp-overview.html)


### PR DESCRIPTION
related to #435

This is the 2nd of 2 PRs to get that change deployed without the
link-checker complaining about a link to an About page that doesn't
exist yet.
