### PR TITLE
Improve the publishing workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,16 @@
+name: Check
+
+on:
+  pull_request
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    container:
+      image: ministryofjustice/cloud-platform-tech-docs-publisher:1.1
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: bin/build.sh
+    - name: Link checker
+      run: bin/check.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: bundle exec middleman build --build-dir docs
+      run: bin/build.sh
+    - name: Link checker
+      run: bin/check.sh
     - name: Run the script
       run: bin/publish.sh
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       run: bin/build.sh
     - name: Link checker
       run: bin/check.sh
-    - name: Run the script
+    - name: Publish
       run: bin/publish.sh
       env:
         PUBLISHING_GIT_TOKEN: ${{ secrets.PUBLISHING_GIT_TOKEN }}

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# This script is called in .github/workflows/*.yml to compile
+# source documents into HTML files in the `docs` directory.
+
+set -euo pipefail
+
+# Check for internal and external broken links The 'grep -v' suppresses
+# annoying warnings due to some of the gem dependencies using functions that
+# have been deprecated in current versions of ruby.
+bundle exec middleman build 2>&1 \
+  --verbose \
+  --build-dir docs \
+  | grep -v "warning: URI.*escape is obsolete"
+

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This script is called by .github/workflows/check.yml after compiling the
+# source documents into HTML files in the `docs` directory.
+#
+# It runs the link checker, so that PRs can be amended if there are any
+# problems, without affecting the published site.
+
+set -euo pipefail
+
+# Check for internal and external broken links The 'grep -v' suppresses
+# annoying warnings due to some of the gem dependencies using functions that
+# have been deprecated in current versions of ruby.
+bundle exec htmlproofer 2>&1 \
+  --http-status-ignore 0,429 \
+  --allow-hash-href \
+  --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" \
+  ./docs | grep -v "warning: URI.*escape is obsolete"
+
+

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -8,9 +8,6 @@
 
 set -euo pipefail
 
-# Check for internal and external broken links
-bundle exec htmlproofer ./docs --http-status-ignore 0,429 --allow-hash-href --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" ./docs
-
 # PUBLISHING_GIT_TOKEN is a secret in the source repository. It should contain a github personal access token
 # with `public_repo` scope, and MoJ SSO enabled.
 REPOSITORY_PATH="https://${PUBLISHING_GIT_TOKEN}@github.com/$GITHUB_PAGES_REPO_OWNER/$GITHUB_PAGES_REPO_NAME.git"


### PR DESCRIPTION
* Create 'build.sh'
* Extract 'check.sh' from 'publish.sh'
* Suppress noisy deprecation warnings
* Add a "check" action on PRs

This change runs a full build and check on all new
PRs, so that any problems are reported *before*
the PR is merged.

fixes https://github.com/ministryofjustice/cloud-platform/issues/2279
