### PR TITLE
Add Onboarding/Migration to the Cloud Platform

### DIFF
--- a/source/documentation/reference/getting-help.html.md.erb
+++ b/source/documentation/reference/getting-help.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Getting Help
 weight: 50
-last_reviewed_on: 2020-09-21
+last_reviewed_on: 2020-10-07
 review_in: 3 months
 ---
 
@@ -28,5 +28,14 @@ Platform.
 
 To book a 30 minute slot, please post to [#ask-cloud-platform]
 
+## Onboarding/Migration to the Cloud Platform
+
+We believe that everything you need to start using the Cloud Platform can be found in this user guide.
+
+However, we appreciate that this can be a daunting task, and the Cloud Platform Team is more than happy to spend time with you on planning your journey to the Cloud Platform. This will enable us to improve the onboarding process.
+
+We can also help you determine [how to host your service] and whether the Cloud Platform is the right option for you.
+
 [#ask-cloud-platform]: https://mojdt.slack.com/messages/C57UPMZLY
 [support-ticket]: http://goo.gl/msfGiS
+[how to host your service]: https://ministryofjustice.github.io/technical-guidance/documentation/standards/hosting.html#how-to-host-services


### PR DESCRIPTION
Added a section on support offered to users for Onboarding/Migration to the Cloud Platform to the Getting Help page of the user guide.