### PR TITLE
Remove link to k8s 1.16 changes page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -84,7 +84,6 @@ the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
  - [Migrating an S3 bucket](documentation/other-topics/s3-bucket-migration.html)
  - [Kibana Circleci Monitoring Dashboards](documentation/other-topics/kibana-circleci-monitoring-dashboards.html)
  - [Namespace/Container Resource Limits](documentation/concepts/namespace-limits.html)
- - [Removing Deprecated APIs for Kubernetes version 1.16](documentation/other-topics/apiversion-changes-k8s-1-16.html)
  - [Checking the GitHub groups in your ID token](documentation/other-topics/check-id-token.html)
 
 ## Reference


### PR DESCRIPTION
This needs to be a separate PR, or the publishing process will complain
about the PR which removes the page.
