### PR TITLE
Remove generator param from pod run command

### DIFF
--- a/source/documentation/other-topics/rds-external-access.html.md.erb
+++ b/source/documentation/other-topics/rds-external-access.html.md.erb
@@ -46,7 +46,6 @@ We will use [ministryofjustice/port-forward][port-forward-image] for this exampl
 kubectl \
   -n [your namespace] \
   run port-forward-pod \
-  --generator=run-pod/v1 \
   --image=ministryofjustice/port-forward \
   --port=5432 \
   --env="REMOTE_HOST=[your database hostname]" \


### PR DESCRIPTION
According to my kubectl 
```
Flag --generator has been deprecated, has no effect and will be removed in the future.
```