### PR TITLE
Update the user guide wrt. CLI `decode-secret`

### DIFF
--- a/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
@@ -245,13 +245,7 @@ To authenticate to your ECR, you will need the `access_key_id` and `secret_acces
 
 *tl;dr* use this command:
 
-      kubectl -n [namespace_name] get secret [name of your secret] -o yaml
-
-Don't forget to base64 decode the `access_key_id` and `secret_access_key` values before using them.
-
-You can pipe the yaml through [this script][decode-script] in order to decode the values, or you can do the following:
-
-      echo 'your_access_key_id_value' | base64 --decode
+      cloud-platform decode-secret -n [namespace_name] -s [name of your secret]
 
 Once you have your `access_key_id` and `secret_access_key`, set up an AWS profile using the AWS cli tool.
 

--- a/source/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html.md.erb
+++ b/source/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html.md.erb
@@ -128,23 +128,16 @@ Access to the cluster is scoped for the namespace the service account was create
 Once the CircleCI service account is created above, you can grab the ca.crt as follows:
 
 ```yaml
-kubectl get secret <NAME-OF-CIRCLECI-SERVICE-ACCOUNT-SECRET> -o yaml -n <YOUR-NAMESPACE> | grep ca.crt
+cloud-platform decode-secret -n <YOUR-NAMESPACE> -s <NAME-OF-CIRCLECI-SERVICE-ACCOUNT-SECRET> | grep ca.crt
 ```
 
 Likewise grab the CircleCI service account token as follows:
 
 ```yaml
-kubectl get secret <NAME-OF-CIRCLECI-SERVICE-ACCOUNT-SECRET> -o yaml -n <YOUR-NAMESPACE> | grep token
-```
-
-The token will need to be decoded as follows:
-
-```yaml
-echo <ENCODED_TOKEN> | base64 --decode
+cloud-platform decode-secret -n <YOUR-NAMESPACE> -s <NAME-OF-CIRCLECI-SERVICE-ACCOUNT-SECRET> | grep token
 ```
 
 Both the ca.crt and token will be added as environment variables by creating a context in the CircleCI console, that holds these values as shown below.
-
 
 ### Linking Repository to CircleCI
 MoJ has as an account with CircleCI, please login to [CircleCI](https://circleci.com) using GitHub credentials. Select project, and if config.yml is in the repo CircleCI will build and run tests.

--- a/source/documentation/getting-started/cloud-platform-cli.html.md.erb
+++ b/source/documentation/getting-started/cloud-platform-cli.html.md.erb
@@ -202,6 +202,42 @@ You should see output similar to this:
 The github teams are listed under `https://k8s.integration.dsd.io/groups` as
 above.
 
+### Base64 decode a kubernetes secret
+
+```bash
+cloud-platform decode-secret -n <namespace_name> -s <secret_name>
+```
+
+e.g.
+
+```bash
+cloud-platform decode-secret -n dstest -s rds-instance-output
+
+{
+    "apiVersion": "v1",
+    "data": {
+        "access_key_id": "AKIAXXXXXXXXXXXXXXXX",
+        "database_name": "db2axxxxxxxxxxxxxx",
+        "database_password": "xxxxxxxxxxxxxxxx",
+        "database_username": "xxxxxxxxxx",
+        "rds_instance_address": "cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com",
+        "rds_instance_endpoint": "cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com:3306",
+        "secret_access_key": "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+        "url": "postgres://xxxxxxxxxx:XXXXXXXXXXXXXXXX@cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com:5432/db2axxxxxxxxxxxxxx"
+    },
+    "kind": "Secret",
+    "metadata": {
+        "creationTimestamp": "2020-06-19T13:43:31Z",
+        "name": "rds-instance-output",
+        "namespace": "dstest",
+        "resourceVersion": "276902169",
+        "selfLink": "/api/v1/namespaces/poornima-dev/secrets/rds-instance-output",
+        "uid": "1f4243d8-ee57-4756-af09-5a8084a89988"
+    },
+    "type": "Opaque"
+}
+```
+
 [cloud platform cli]: https://github.com/ministryofjustice/cloud-platform-cli#cloud-platform-tool-cli
 [releases]: https://github.com/ministryofjustice/cloud-platform-cli#cloud-platform-tool-cli/releases
 [golang]: https://golang.org

--- a/source/documentation/getting-started/ecr-setup.html.md.erb
+++ b/source/documentation/getting-started/ecr-setup.html.md.erb
@@ -52,12 +52,13 @@ After your ECR has been created, there will be a [Kubernetes secret] in your nam
 
 The secret stores the IAM access keys to authenticate with the registry, and the actual repository URL.
 
-To retrieve the credentials:
+Use the [Cloud Platform CLI] to retrieve the credentials:
 
 ```
-kubectl -n <namespace_name> get secrets/ecr-repo-[your-namespace] --template={{.data.access_key_id}} | base64 --decode
-kubectl -n <namespace_name> get secrets/ecr-repo-[your-namespace] --template={{.data.secret_access_key}} | base64 --decode
+cloud-platform decode-secret -n <namespace_name> -s ecr-repo-[your-namespace]
 ```
+
+Look for the `access_key_id` and `secret_access_key` values.
 
 ## Managing your ECR repository
 

--- a/source/documentation/other-topics/upgrade-rds-db.html.md.erb
+++ b/source/documentation/other-topics/upgrade-rds-db.html.md.erb
@@ -67,38 +67,41 @@ We will use these credentials with the [AWS CLI tool] to describe and then modif
 kubectl -n [your namespace] get secret
 ```
 
-This will give you a list of the secrets in your namespace. Identify the RDS instance secret via its name, and decode its contents:
+This will give you a list of the secrets in your namespace. Identify the RDS
+instance secret via its name, and decode its contents using the [cloud platform cli]:
 
 ```
-kubectl -n [your namespace] get secret [secret name] -o yaml | ./bin/decode.rb
+cloud-platform decode-secret -n [your namespace] -s [secret name]
 ```
-
-> The `bin/decode.rb` script is [here](https://github.com/ministryofjustice/cloud-platform-environments)
 
 Here is a redacted example:
 
 ```
-$ kubectl -n dstest get secret rds-instance-output -o yaml | ./bin/decode.rb
----
-apiVersion: v1
-data:
-  access_key_id: AKIAXXXXXXXXXXXXXXXX
-  database_name: db2axxxxxxxxxxxxxx
-  database_password: XXXXXXXXXXXXXXXX
-  database_username: xxxxxxxxxx
-  rds_instance_address: cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com
-  rds_instance_endpoint: cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com:5432
-  secret_access_key: qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
-  url: postgres://xxxxxxxxxx:XXXXXXXXXXXXXXXX@cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com:5432/db2axxxxxxxxxxxxxx
-kind: Secret
-metadata:
-  creationTimestamp: '2020-10-27T11:37:02Z'
-  name: rds-instance-output
-  namespace: dstest
-  resourceVersion: '416006008'
-  selfLink: "/api/v1/namespaces/dstest/secrets/rds-instance-output"
-  uid: 31a0ea23-f10c-4494-86fb-fbeb844d7f21
-type: Opaque
+cloud-platform decode-secret -n dstest -s rds-instance-output
+
+{
+    "apiVersion": "v1",
+    "data": {
+        "access_key_id": "AKIAXXXXXXXXXXXXXXXX",
+        "database_name": "db2axxxxxxxxxxxxxx",
+        "database_password": "xxxxxxxxxxxxxxxx",
+        "database_username": "xxxxxxxxxx",
+        "rds_instance_address": "cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com",
+        "rds_instance_endpoint": "cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com:3306",
+        "secret_access_key": "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+        "url": "postgres://xxxxxxxxxx:XXXXXXXXXXXXXXXX@cloud-platform-1111111111111111.cdwm328dlye6.eu-west-2.rds.amazonaws.com:5432/db2axxxxxxxxxxxxxx"
+    },
+    "kind": "Secret",
+    "metadata": {
+        "creationTimestamp": "2020-06-19T13:43:31Z",
+        "name": "rds-instance-output",
+        "namespace": "dstest",
+        "resourceVersion": "276902169",
+        "selfLink": "/api/v1/namespaces/poornima-dev/secrets/rds-instance-output",
+        "uid": "1f4243d8-ee57-4756-af09-5a8084a89988"
+    },
+    "type": "Opaque"
+}
 ```
 
 Use the values you see to set the following environment variables:
@@ -179,3 +182,4 @@ When this PR is merged, the pipeline will upgrade your RDS instance.
 [major version upgrade]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion
 [parameter group]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html
 [AWS CLI tool]: https://aws.amazon.com/cli/
+[cloud platform cli]: ../getting-started/cloud-platform-cli.html


### PR DESCRIPTION
Update all references to decoding kubernetes 
secrets to use the cloud-platform CLI

Also, update the page about the CLI to describe
this feature

depends on https://github.com/ministryofjustice/cloud-platform-cli/pull/62