### PR TITLE
Fix a broken link

### DIFF
--- a/source/documentation/concepts/namespace-limits.html.md.erb
+++ b/source/documentation/concepts/namespace-limits.html.md.erb
@@ -10,15 +10,15 @@ The cloud platform is a single kubernetes cluster, hosting multiple different Mo
 
 The smallest unit of work we ask the cluster to manage is a container, and the largest is a [namespace]. The cluster has several [worker nodes], which supply the memory and CPU capacity on which workloads can run. So, kubernetes has to solve a classic [packing problem] - run a bunch of different workloads on the cluster, putting them on different worker nodes in the most efficient way possible. But, the cluster can't be sure in advance how much resource (memory and CPU) any given container is going to need.
 
-To help with this, we specify **request limits**. 
+To help with this, we specify **request limits**.
 
 > This article will use "request" because that's the official kubernetes term, but request is a slightly awkward term here. It might be better to think of "reserving" rather than requesting resources.
 
 Essentially, a request limit says to kubernetes, "this thing is probably going to need this much memory and this much CPU in order to do its job." So, whenever it encounters a request limit, the [kube-scheduler] sets aside that amount of memory and CPU, and ring-fences it so that it's guaranteed to be available.
 
-The other kind of limits in kubernetes are known as **hard limits**. These are important at runtime, as opposed to request limits, which are important for the scheduling decisions the cluster makes before your workloads start to run. 
+The other kind of limits in kubernetes are known as **hard limits**. These are important at runtime, as opposed to request limits, which are important for the scheduling decisions the cluster makes before your workloads start to run.
 
-The name "hard limits" suggests these are limits that kubernetes will enforce, so that the workload will be terminated if it exceeds them. The reality is a little more nuanced. 
+The name "hard limits" suggests these are limits that kubernetes will enforce, so that the workload will be terminated if it exceeds them. The reality is a little more nuanced.
 
 If the cluster has capacity available on the node where the workload is running, it may allow it to consume more resources than the hard limit specifies. But, it will flag the workload such that, if the node runs out of resources and kubernetes needs to evict pods, the pods from the offending workload will be first in line to be evicted.
 
@@ -66,13 +66,11 @@ The diagram above shows a namespace with a deployment consisting of four contain
 
 So far, we've only been talking about what resources we are **requesting**, and it's clear that we can quickly run out of capacity in the cluster if we request too many resources. But, how closely does what we request match what we use?
 
-We have created [this script][namespace-reporter] that you can run to see how your namespace is doing.
+We have created [this report][namespace-reporter] that you can run to see how your namespace is doing (click on a namespace name to get more details. If yours is not visible, you can click on any namespace and replace the namespace name in the browser address bar to see yours).
 
 Here is the current result (25/07/19) from running the script against the `monitoring` namespace (where things like [prometheus] and [alert-manager] run)
 
 ```
-$ ./bin/namespace-reporter.rb monitoring
-
 Namespace: monitoring
 
 Request limit:        CPU: 10000,     Memory: 24000
@@ -109,6 +107,6 @@ For this reason, we avoid specifying memory and CPU limits on namespaces, and ou
 [mebibytes]: https://en.wikipedia.org/wiki/Mebibyte
 [pods]: https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/
 [deployment-yaml]: https://raw.githubusercontent.com/ministryofjustice/fb-av/6cdba5db4e2feb440c7b6a303f241728b9cee5f8/deploy/fb-av-chart/templates/deployment.yaml
-[namespace-reporter]: https://github.com/ministryofjustice/cloud-platform-environments/blob/master/bin/namespace-reporter.rb
+[namespace-reporter]: https://reports.cloud-platform.service.justice.gov.uk/namespace_usage_cpu
 [prometheus]: https://prometheus.io/
 [alert-manager]: https://prometheus.io/docs/alerting/alertmanager/


### PR DESCRIPTION
The namespace reporter script is not available for end-users anymore.
Instead, the same information is published via the [cloud platform
reports](https://reports.cloud-platform.service.justice.gov.uk/namespace_usage_cpu)
web app.
