### PR TITLE
For link-checking, ignore links to MoJ GitHub

### DIFF
--- a/bin/check.sh
+++ b/bin/check.sh
@@ -8,12 +8,25 @@
 
 set -euo pipefail
 
+# There are a couple of cases where links will appear to be broken:
+#
+# 1. There is a `View source` link on every page, which will be broken for any
+#    files that have not yet been merged into the default branch of the
+#    documentation repo.
+# 2. If the documentation includes a link to any private repositories, those
+#    links will seem to be broken, from the link-checker's POV.
+#
+# To avoid these problems, we tell the link-checker to ignore any links that
+# point to MoJ GitHub entities.
+MOJ_GITHUB=/https...github.com.ministryofjustice.*/
+
 # Check for internal and external broken links The 'grep -v' suppresses
 # annoying warnings due to some of the gem dependencies using functions that
 # have been deprecated in current versions of ruby.
 bundle exec htmlproofer 2>&1 \
   --http-status-ignore 0,429 \
   --allow-hash-href \
+  --url-ignore "${MOJ_GITHUB}" \
   --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" \
   ./docs | grep -v "warning: URI.*escape is obsolete"
 


### PR DESCRIPTION
The link-checking step always fails for new pages, because their "View
Source" links point to the URL of the file in the github repository's
`main` branch, and new pages don't exist in the `main` branch until the
PR which adds them has been merged.

This change makes the link-checker ignore any URLs which target pages in
the MoJ Github organisation. This is overkill, and it means any links
pointing to MoJ github endpoints which have been renamed will not be
reported. But, this is probably a tradeoff worth making, in the short
term.

I would suggest we have a separate, scheduled link-checker that crawls
the **published** website (or which only operates **from** the `main`
branch), and reports on any broken links it finds.
