### PR TITLE
Add a new page to confirm link-check fails

### DIFF
--- a/source/documentation/concepts/new-page.html.md.erb
+++ b/source/documentation/concepts/new-page.html.md.erb
@@ -1,0 +1,9 @@
+---
+title: New Page to test "View Source" Link-checking
+last_reviewed_on: 2021-02-09
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero sed arcu vehicula ultricies a non tortor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ut gravida lorem. Ut turpis felis, pulvinar a semper sed, adipiscing id dolor. Pellentesque auctor nisi id magna consequat sagittis. Curabitur dapibus enim sit amet elit pharetra tincidunt feugiat nisl imperdiet. Ut convallis libero in urna ultrices accumsan. Donec sed odio eros. Donec viverra mi quis quam pulvinar at malesuada arcu rhoncus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In rutrum accumsan ultricies. Mauris vitae nisi at sem facilisis semper ac in est


### PR DESCRIPTION
The link-checker should fail for this page, because the "View Source"
link on the page will point to the URL of this page on the `main` branch
of this github repository, and the file doesn't exist in the main branch
yet.
