### PR TITLE
Fix Gov.UK -> GOV.UK capitalisation

### DIFF
--- a/source/documentation/getting-started/prototype-kit.html.md.erb
+++ b/source/documentation/getting-started/prototype-kit.html.md.erb
@@ -1,12 +1,12 @@
 ---
-title: Create a Gov.UK Prototype Kit site
+title: Create a GOV.UK Prototype Kit site
 last_reviewed_on: 2021-02-04
 review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
 
-The cloud platform makes it easy to set up and host a [Gov.UK Prototype Kit]
+The cloud platform makes it easy to set up and host a [GOV.UK Prototype Kit]
 website.
 
 This guide will walk you through the process.
@@ -138,7 +138,7 @@ safety feature.
 Shortly after you merge the PR, your namespace will be removed from the Cloud
 Platform.
 
-[Gov.UK Prototype Kit]: https://govuk-prototype-kit.herokuapp.com/docs
+[GOV.UK Prototype Kit]: https://govuk-prototype-kit.herokuapp.com/docs
 [MoJ GitHub Organisation]: https://github.com/ministryofjustice/
 [Cloud Platform CLI]: ./cloud-platform-cli.html
 [cloud-platform-environments]: https://github.com/ministryofjustice/cloud-platform-environments

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -18,7 +18,7 @@ the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
 - [Overview of the Cloud Platform](documentation/concepts/cp-overview.html)
 - [The Cloud Platform CLI](documentation/getting-started/cloud-platform-cli.html)
 - [Deploy your first Hello World application](documentation/deploying-an-app/helloworld-app-deploy.html)
-- [Create a Gov.UK Prototype Kit site](documentation/getting-started/prototype-kit.html)
+- [Create a GOV.UK Prototype Kit site](documentation/getting-started/prototype-kit.html)
 - [Set up continuous deployment using GitHub Actions](documentation/deploying-an-app/github-actions-continuous-deployment.html)
 
 ## How-to guides


### PR DESCRIPTION
This PR changes `Gov.UK` to `GOV.UK` as per the stylisation on [GOV.UK](https://gov.uk).