### PR TITLE
Ignore 403 errors

### DIFF
--- a/bin/check.sh
+++ b/bin/check.sh
@@ -24,7 +24,7 @@ MOJ_GITHUB=/https...github.com.ministryofjustice.*/
 # annoying warnings due to some of the gem dependencies using functions that
 # have been deprecated in current versions of ruby.
 bundle exec htmlproofer 2>&1 \
-  --http-status-ignore 0,429 \
+  --http-status-ignore 0,429,403 \
   --allow-hash-href \
   --url-ignore "${MOJ_GITHUB}" \
   --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" \


### PR DESCRIPTION
Some external links return 403 even if the page is working correctly. This maybe due to the website expecting cookies when requesting