### PR TITLE
Add page about Apply Pipeline

### DIFF
--- a/source/documentation/deploying-an-app/cleaning-up.html.md.erb
+++ b/source/documentation/deploying-an-app/cleaning-up.html.md.erb
@@ -24,8 +24,9 @@ deleting the folder:
 
 ...and all its contents, from the [cloud-platform-environments][envrepo] repository.
 
-Merging this [PR] will trigger an automated pipeline which will delete all of
-your namespace's AWS resources, followed by the namespace itself.
+Merging this [PR] will trigger the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html),
+which will delete all of your namespace's AWS resources, followed by the
+namespace itself.
 
 > NB: If you have set up a CI/CD pipeline, which deploys into your namespace,
 then this should be deleted first, so that anything you delete later is not

--- a/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
@@ -31,7 +31,7 @@ deploying changes to the application:
 * Tag the image and push it to your ECR
 * Update your kubernetes files to deploy the updated application
 
-The process of building an image and pushing it to an ECR will normally be carried out by a build pipeline. For this initial walkthrough, we will go through these steps manually. Later we will go through an example of setting up a [CircleCI][circleci] job to do this automatically. The steps are similar if you're using other CI/CD tools such as [TravisCI][travisci].
+The process of building an image and pushing it to an ECR will normally be carried out an application's build pipeline. However, for this initial walkthrough, we will go through these steps manually. Later we will go through an example of setting up a [CircleCI][circleci] job to do this automatically. The steps are similar if you're using other CI/CD tools such as [TravisCI][travisci].
 
 ## Prerequisites
 
@@ -208,8 +208,9 @@ To update our application, we need to:
 * Update our `deployment.yaml` file with the new image details
 * Apply the updated yaml file to kubernetes
 
-> Everything but the first step will usually be done automatically by your
-> CI/CD pipeline, but it's worth understanding what's going on.
+> Everything but the first step would usually be done automatically by your
+> application's CI/CD pipeline, but we're doing it manually here for ease of
+> understanding.
 
 ## Step 3 - Create an Amazon ECR
 

--- a/source/documentation/getting-started/ecr-setup.html.md.erb
+++ b/source/documentation/getting-started/ecr-setup.html.md.erb
@@ -40,9 +40,9 @@ You need to have the [Cloud Platform CLI] tool installed.
 
 5. Raise a PR to have your change approved
 
-Once your pull request has been approved and merged, it will trigger our build pipeline which will create your ECR.
+Once your pull request has been approved and merged, it will trigger the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html) which will create your ECR.
 
-For more information about the terraform module being used, please read the documentation [here][module documentation].
+For more information about the terraform module being used, please read the documentation: [ECR terraform module][module documentation]
 
 ## Accessing the credentials
 
@@ -60,7 +60,7 @@ Look for the `access_key_id` and `secret_access_key` values.
 
 ## GitHub Actions
 
-If you are using [GitHub Actions] for your deployment pipeline, the ECR module can automatically manage [GitHub Actions Secrets] containing the ECR name, and the AWS access/secret keypair required to access it.
+If you are using [GitHub Actions] for your application deployment pipeline, the ECR module can automatically manage [GitHub Actions Secrets] containing the ECR name, and the AWS access/secret keypair required to access it.
 
 In the `resources/ecr.tf` file, you should see this section:
 

--- a/source/documentation/getting-started/env-create.html.md.erb
+++ b/source/documentation/getting-started/env-create.html.md.erb
@@ -57,8 +57,8 @@ location in the repository.
 
 Please create a new branch, add the new files and raise a pull request. The
 cloud platform team need to approve your pull request before you can merge it.
-Once you have done this, a build pipeline will create your namespace on the
-cluster.
+Once you have done this, the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html)
+will create your namespace on the cluster.
 
 Please create **one PR per namespace** i.e. if you need namespaces `myapp-dev`,
 `myapp-staging` and `myapp-prod`, please raise a separate PR for each one. This
@@ -75,8 +75,9 @@ This is all you need to do in order to create your namespace.
 
 ## Accessing your environments
 
-Once the pipeline has completed you will be able to check that your environment
-is available by running:
+The [Apply Pipeline](/documentation/other-topics/apply-pipeline.html) deployment
+should complete in about 3 minutes, and you will be able to check that your
+environment is available by running:
 
 `$ kubectl get namespaces`
 
@@ -155,11 +156,12 @@ metadata:
     ...
 ```
 
-The namespace is your (team's) 'private' part of the cluster. The name of
-your namespace must be unique across the whole of the cluster. If you try to
-create a new namespace using the name of one which already exists, you will get
-an error when you try to apply the generated kubernetes config files (or when
-our build pipeline applies them on your behalf).
+The namespace is your (team's) 'private' part of the cluster. The name of your
+namespace must be unique across the whole of the cluster. If you try to create a
+new namespace using the name of one which already exists, you will get an error
+when you try to apply the generated kubernetes config files (or when the [Apply
+Pipeline](/documentation/other-topics/apply-pipeline.html) applies them on your
+behalf).
 
 For 'real' services, this is very unlikely to be a problem - most services have
 distinct names, so namespace name conflicts are unlikely. But, if you are

--- a/source/documentation/getting-started/prototype-kit.html.md.erb
+++ b/source/documentation/getting-started/prototype-kit.html.md.erb
@@ -76,16 +76,16 @@ Create a new branch, `git add` the new folder and then raise a pull request.
 
 Once a member of the Cloud Platform team has approved your PR, merge it.
 
-When you merge the PR, the Cloud Platform CI/CD pipeline will create your
-namespace and github repository. The github repository has a [GitHub Actions]
-workflow which will continuously deploy any changes made to the `main` branch
-of the repository.
+When you merge the PR, the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html)
+will create your namespace and github repository. The github repository has a
+deployment workflow, implemented as a [GitHub Actions] workflow, which will
+continuously deploy any changes made to the `main` branch of the repository.
 
 ## Caveats
 
 There are a few things to be aware of, concerning your prototype kit site:
 
-* The continuous deployment workflow usually takes around 5 minutes to run
+* The deployment workflow usually takes around 5 minutes to run
 
 * The very first run of the deployment workflow will fail. This is because the
 github repository (and its deployment workflow) has to be created before some
@@ -112,8 +112,7 @@ resource "github_branch_protection" "default" {
 }
 ```
 
-> If you use the GitHub UI to disable branch protection, the Cloud Platform
-deployment pipeline will re-enable it shortly afterwards.
+> If you use the GitHub UI to disable branch protection, the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html) will re-enable it shortly afterwards.
 >
 > The only way to permanently disable it is to remove it from the terraform
 source code.
@@ -131,7 +130,7 @@ delete your repository
 
 1. Merge the PR
 
-> The Cloud Platform deployment pipeline has the GitHub privileges required to
+> The [Apply Pipeline](/documentation/other-topics/apply-pipeline.html) has the GitHub privileges required to
 **create** repositories, but not to **delete** them. This is a deliberate
 safety feature.
 

--- a/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.html.md.erb
+++ b/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.html.md.erb
@@ -8,7 +8,7 @@ review_in: 3 months
 
 
 ## Overview
-[Pingdom](https://my.pingdom.com) is a global performance and availability monitor for your web application. The aim of this document is to provide you with the necessary information to create Pingom checks via the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments) pipeline, and then send failing checks to a Slack channel of your choosing.
+[Pingdom](https://my.pingdom.com) is a global performance and availability monitor for your web application. The aim of this document is to provide you with the necessary information to create Pingdom checks via the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments) pipeline, and then send failing checks to a Slack channel of your choosing.
 
 ## Prerequisites
 This guide assumes the following:
@@ -83,7 +83,7 @@ Add the below 2 files in in the resources directory of your namespace in your [c
 
   All resources, including Pingdom checks **must** be tagged and adhere to the technical guidance outlined [here](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html). Ensure your check has appropriate tags before submitting a pull request.
 
-Once reviewed and merged to main, the pipeline will create your check in the MoJ Pingdom account.
+Once reviewed and merged to main, the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html) will create your check in the MoJ Pingdom account.
 
 ### Adding Slack notification
 You can enable the option to send a failing alert to Slack via a webhook by simply adding Pingdom integration id. You need administrator permissions to manage the mojdt [Pingdom Slack](https://slack.com/apps/A0F814AV7-pingdom?next_id=0) webhook and then [Pingdom](https://my.pingdom.com) to create the integration id.

--- a/source/documentation/monitoring-an-app/how-to-use-cloudwatch-datasource.html.md.erb
+++ b/source/documentation/monitoring-an-app/how-to-use-cloudwatch-datasource.html.md.erb
@@ -34,7 +34,7 @@ data:
     }
 ```
 
-Add the `ConfigMap` above to your namespace folder in the [environments repo][env-repo]. Once the ConfigMap is applied though the concourse pipeline, your dashboard should be visible in Grafana shortly.
+Add the `ConfigMap` above to your namespace folder in the [environments repo][env-repo]. Once the ConfigMap is applied though the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html), your dashboard should be visible in Grafana shortly.
 
 Dynamic queries using dimension wildcards:
 

--- a/source/documentation/other-topics/apply-pipeline.html.md.erb
+++ b/source/documentation/other-topics/apply-pipeline.html.md.erb
@@ -1,0 +1,46 @@
+---
+title: Apply Pipeline
+last_reviewed_on: 2021-06-24
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+## Introduction
+
+The **Apply Pipeline** is the part of Cloud Platform that continuously deploys the [environments repo](https://github.com/ministryofjustice/cloud-platform-environments) into Cloud Platform's Kubernetes cluster and AWS account. Service teams typically define their Kubernetes namespace and AWS resources in the environments repo, and and the Apply Pipeline is what gets it applied.
+
+(Don't confuse it with the **application pipelines**, which are created and managed by service teams. These deploy the Kubernetes resources which make up the application. The application in turn relies on the resources created by the Apply Pipeline - the namespace the application runs in and AWS services that it uses.)
+
+## How it operates
+
+The Apply Pipeline is triggered when a Pull Request on the [environments repo](https://github.com/ministryofjustice/cloud-platform-environments) is merged to `main`. The Apply Pipeline deploys the changes to whichever environments were changed in the PR.
+
+Essentially it does:
+
+```sh
+kubectl -n your-namespace apply -f *.yaml
+cd resources
+terraform plan
+terraform apply
+```
+
+It takes a minute to start the job and then 1 to 2 minutes to run.
+
+## Viewing the Apply Pipeline
+
+You can see the running of the Apply Pipeline in [Concourse's "Apply-namespace-changes-live-1" pipeline](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-namespace-changes-live-1)
+
+Usage:
+
+* Sign in using your GitHub identity
+* Select the build corresponding to your PR merge (other people's changes to environments also show up here). The latest build is at the top, but you can also identify your one by the merge commit hash.
+* Select `task: apply-namespace-changes` to see the logs, where terraform is applied.
+
+### Success and failures
+
+The colour of the header is green if the job was successful, or red for failure. A failing apply can disrupt other Service Teams who wish to apply their environment changes. So in this case, the Cloud Platform team will work quickly, hopefully with the PR author involved, to resolve or reverse changes, to resolve the failure.
+
+## Questions
+
+If you have questions about the running of the Apply Pipeline, ask the team in [#ask-cloud-platform](https://mojdt.slack.com/messages/C57UPMZLY/team/U58MLFA0M/).

--- a/source/documentation/other-topics/long-running-env-operations.html.md.erb
+++ b/source/documentation/other-topics/long-running-env-operations.html.md.erb
@@ -13,10 +13,11 @@ This means a scheduled [apply pipeline] run might try to operate on a namespace
 while it is being modified.
 
 We use [Terraform state locking] to ensure that this does not cause serious
-problems, but at the least it would cause the apply pipeline to timeout with an
-error if it can't acquire a lock on the target namespace's terraform state.
+problems, but at the least it would cause the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html)
+to timeout with an error if it can't acquire a lock on the target namespace's
+terraform state.
 
-For this reason, we have a mechanism to allow the apply pipeline to skip
+For this reason, we have a mechanism to allow the Apply Pipeline to skip
 individual namespaces during long-running operations.
 
 To use this feature:

--- a/source/documentation/other-topics/rds-snapshots.html.md.erb
+++ b/source/documentation/other-topics/rds-snapshots.html.md.erb
@@ -80,7 +80,7 @@ It is important to retain the original settings associated with the DB instance 
 #### 4. Contact the Cloud Platform team about the restore, providing the `db-instance-identifier` and the PR raised.
 
 #### 5. Before the PR can be merged, the Cloud Platform team have to:
-* pause the concourse pipeline, and
+* pause the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html), and
 * rename the DB Instance via the AWS console
 
 This allows the pipeline to create the new DB Instance from the snapshot, using the same name and settings as the original, and preserves the database endpoint and credentials.
@@ -93,7 +93,7 @@ This allows the pipeline to create the new DB Instance from the snapshot, using 
 >
 > Once the the terraform apply is successful, and the new DB instance has been created, revert the changes made for `db_engine_version`.
 
-#### 6. Merge the PR to master and check that the build pipeline creates the new DB instance with the same identifier and endpoints. The Cloud Platform team can also apply your changes manually if this is time critical.
+#### 6. Merge the PR to master and check that the Apply Pipeline creates the new DB instance with the same identifier and endpoints. The Cloud Platform team can also apply your changes manually if this is time critical.
 
 Once the new DB instance is restored and available, your application should be able to access the database with the same database credentials and endpoint as before.
 

--- a/source/documentation/other-topics/secrets.html.md.erb
+++ b/source/documentation/other-topics/secrets.html.md.erb
@@ -18,7 +18,7 @@ These are any kind of secret that is owned by a specific user (eg. GitHub or AWS
 
 ### System Secrets
 
-These are secrets used in system components, usually configured by someone who manages, configures or supports the system. For example, when setting up a CI pipeline, the credentials it uses to fetch the source code and push the produced artifacts to a repository are considered system secrets.
+These are secrets used in system components, usually configured by someone who manages, configures or supports the system. For example, when setting up an application CI pipeline, the credentials it uses to fetch the source code and push the produced artifacts to a repository are considered system secrets.
 
 These should not be tied to an individual user (who might leave the organisation). Instead, machine users should be employed. The responsibility of managing these secrets securely lies with the owner of the system.
 

--- a/source/documentation/other-topics/upgrade-rds-db.html.md.erb
+++ b/source/documentation/other-topics/upgrade-rds-db.html.md.erb
@@ -35,9 +35,9 @@ If you want to use this method, you can treat it like any other [database migrat
 
 The upgrade process involves these steps:
 
-* Raise and merge a PR to [tell the apply pipeline to skip your namespace][long-running]
+* Raise and merge a PR to [tell the Apply Pipeline to skip your namespace][long-running]
 * Alter your RDS instance to use the default [parameter group] for your **current** PostgreSQL version
-* Raise and merge a PR to change your PostgreSQL version to the one you want - the pipeline will handle the upgrade for you
+* Raise and merge a PR to change your PostgreSQL version to the one you want - the Apply Pipeline will handle the upgrade for you
 * Raise another PR to [remove the "skip file"][long-running] from your namespace
 
 ### Advantages
@@ -159,7 +159,7 @@ aws rds modify-db-instance --db-instance-identifier $db \
 
 This will output a few screenfuls of JSON, which you can ignore. After making the change, repeat the `describe-db-instances` command to confirm that the change has worked.
 
-> It is important that the apply pipeline is paused, at this point, or it will revert the above change, and your upgrade will fail.
+> It is important that the Apply Pipeline is paused, at this point, or it will revert the above change, and your upgrade will fail.
 
 ##### Upgrade your RDS instance
 
@@ -175,7 +175,7 @@ e.g. To upgrade from PostgreSQL 9.5 to 9.6 (this is a [major version upgrade]), 
 +  rds_family = "postgres9.6"
 ```
 
-When this PR is merged, the pipeline will upgrade your RDS instance.
+When this PR is merged, the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html) will upgrade your RDS instance.
 
 > In testing, data in the database was preserved, and the total downtime of the RDS instance was approx. 7 minutes. You need to carry out your own tests in your non-production namespace(s) to confirm that this behaviour is similar and acceptable, for your service.
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -94,6 +94,7 @@ the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
  - [Namespace/Container Resource Limits](documentation/concepts/namespace-limits.html)
  - [Checking the GitHub groups in your ID token](documentation/other-topics/check-id-token.html)
  - [Cloud Platform Disaster Recovery](documentation/other-topics/cloud-platform-disaster-recovery.html)
+ - [Apply Pipeline](documentation/other-topics/apply-pipeline.html)
 
 ## Reference
 - [Cloud Platform Operational Processes](documentation/reference/operational-processes.html)


### PR DESCRIPTION
Why? When I setup an environment I was confused about how long it
would take to create and where errors would show.

I've also:

* added links to this page in all the relevant pages elsewhere
* tried to standardize the language to Apply Pipeline and 'application pipeline'
  to help differentiate them in users' mental models.