### PR TITLE
Add  auto-approval on document review PR's

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Auto-approval check
         id: approve_pr_check
-        uses: ministryofjustice/github-actions/approve-doc-review@add-docs-check
+        uses: ministryofjustice/github-actions/approve-doc-review@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -30,11 +30,14 @@ jobs:
           git diff origin/main HEAD > changes
 
       - name: Auto-approval check
+        id: approve_pr_check
         uses: ministryofjustice/github-actions/approve-doc-review@add-docs-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Print the GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+      - name: Approving PR
+        uses: hmarr/auto-approve-action@v2
+
+        if: steps.approve_pr_check.outputs.review_pr == 'true'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN  }}"

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -3,9 +3,6 @@ name: Auto-approve a pull request
 on:
   pull_request
 
-env:
-  HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
-
 jobs:
   check-diff:
     runs-on: ${{ matrix.os }}
@@ -33,9 +30,6 @@ jobs:
         uses: ministryofjustice/github-actions/approve-doc-review@add-docs-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get the owner of the head repository
-        run: echo "head owner = ${{ env.HEAD_OWNER }}"
 
       - name: Print the GitHub context
         env:

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -38,6 +38,6 @@ jobs:
         run: echo "head owner = ${{ env.HEAD_OWNER }}"
 
       - name: Print the GitHub context
-          env:
-            GITHUB_CONTEXT: ${{ toJson(github) }}
-          run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -21,14 +21,6 @@ jobs:
         run: |
           git diff origin/main HEAD > changes
 
-      - run: |
-          cat changes
-
-      - name: Copy changes file so next check can read it
-        run: |
-          mkdir ${HOME}/work/_temp/_github_home
-          cp ${HOME}/changes ${HOME}/work/_temp/_github_home/.
-
       - name: Auto-approval check
         uses: ministryofjustice/github-actions/approve-doc-review@add-docs-check
         env:

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -24,10 +24,6 @@ jobs:
         run: |
           git diff origin/main HEAD > changes
 
-
-      - name: Get the owner of the head repository
-        run: echo "head owner = ${{ env.HEAD_OWNER }}"
-
       - name: Copy changes file so next check can read it
         run: |
           mkdir ${HOME}/work/_temp/_github_home
@@ -37,3 +33,11 @@ jobs:
         uses: ministryofjustice/github-actions/approve-doc-review@add-docs-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get the owner of the head repository
+        run: echo "head owner = ${{ env.HEAD_OWNER }}"
+
+      - name: Print the GitHub context
+          env:
+            GITHUB_CONTEXT: ${{ toJson(github) }}
+          run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -6,6 +6,9 @@ on:
       - 'main'
   # pull_request
 
+env:
+  HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+
 jobs:
   check-diff:
     runs-on: ${{ matrix.os }}
@@ -24,8 +27,9 @@ jobs:
         run: |
           git diff origin/main HEAD > changes
 
-      - run: |
-          cat changes
+
+      - name: Get the owner of the head repository
+        run: echo "head owner = ${{ env.HEAD_OWNER }}"
 
       - name: Copy changes file so next check can read it
         run: |

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -1,7 +1,10 @@
 name: Auto-approve a pull request
 
 on:
-  pull_request
+  workflow_dispatch:
+    branches:
+      - 'main'
+  # pull_request
 
 jobs:
   check-diff:

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -1,0 +1,20 @@
+name: Auto-approve a pull request
+
+on:
+  pull_request
+
+jobs:
+  check-diff:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v1
+
+      - name: Run git diff against repository
+        run: |
+          git diff --name-only --diff-filter=AM ${{ github.event.before }} ${{ github.sha }}

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   PR_OWNER: ${{ github.actor }}
-  GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
+  GITHUB_OAUTH_TOKEN: ${{ secrets.DOCUMENT_REVIEW_GITHUB }}
 
 jobs:
   check-diff:

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   PR_OWNER: ${{ github.actor }}
+  GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_OAUTH_TOKEN }}
 
 jobs:
   check-diff:

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -27,6 +27,11 @@ jobs:
       - run: |
           cat changes
 
+      - name: Copy changes file so next check can read it
+        run: |
+          mkdir ${HOME}/work/_temp/_github_home
+          cp ${HOME}/changes ${HOME}/work/_temp/_github_home/.
+
       - name: Auto-approval check
         uses: ministryofjustice/github-actions/approve-doc-review@add-docs-check
         env:

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -21,6 +21,9 @@ jobs:
         run: |
           git diff origin/main HEAD > changes
 
+      - run: |
+          cat changes
+
       - name: Copy changes file so next check can read it
         run: |
           mkdir ${HOME}/work/_temp/_github_home

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -3,6 +3,9 @@ name: Auto-approve a pull request
 on:
   pull_request
 
+env:
+  PR_OWNER: ${{ github.actor }}
+
 jobs:
   check-diff:
     runs-on: ${{ matrix.os }}
@@ -16,6 +19,10 @@ jobs:
         uses: actions/checkout@v2
       - run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+      - name: owner of PR
+        run: |
+          echo "$PR_OWNER"
 
       - name: Run git diff against repository
         run: |

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 env:
-  PR_OWNER: ${{ github.actor }}
+  PR_OWNER: ${{ github.event.pull_request.user.login }}
   GITHUB_OAUTH_TOKEN: ${{ secrets.DOCUMENT_REVIEW_GITHUB }}
 
 jobs:

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -19,4 +19,7 @@ jobs:
 
       - name: Run git diff against repository
         run: |
-          git diff origin/main HEAD
+          git diff origin/main HEAD > changes
+
+      - run: |
+          cat changes

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -1,10 +1,7 @@
 name: Auto-approve a pull request
 
 on:
-  workflow_dispatch:
-    branches:
-      - 'main'
-  # pull_request
+  pull_request
 
 env:
   HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -23,3 +23,8 @@ jobs:
 
       - run: |
           cat changes
+
+      - name: Auto-approval check
+        uses: ministryofjustice/github-actions/approve-doc-review@add-docs-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -13,8 +13,10 @@ jobs:
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+      - run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
       - name: Run git diff against repository
         run: |
-          git diff --name-only --diff-filter=AM ${{ github.event.before }} ${{ github.sha }}
+          git diff origin/main HEAD


### PR DESCRIPTION
Overview
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/3019 and relates to the creation of a GitHub action that will auto-approve a "document review" PR from a Cloud Platform team member.

What is a document review
---
In this instance a document reviewal is a process that a member of the team follows to keep our documentation up to date. Each day a member of the team receives a list of documents that have expired. This list is then traversed by the team member who will read the expired document and change the `last_reviewed_on` value in a GitHub repository. The change has to follow the generic pull request process so needs another team member to approve.

What does this action do
---
This action will sit in a GitHub repository where the reviewal process commences (cloud-platform-user-guide or cloud-platform). When a PR is triggered it will check the following:
- Does the PR only contain changes that are prefixed with either `+last_reviewed_on` or `-last_reviewed_on`?
- Is the owner of the PR (the team member who raised it) a member of the `WebOps` GitHub team in the `ministryofjustice` organisation?

If both the conditions are met a pass is sent to the step in the GitHub action and it can then auto-approve the PR.