### PR TITLE
Add doc "What can be hosted on CP"

### DIFF
--- a/source/documentation/concepts/cp-tech-overview.html.md.erb
+++ b/source/documentation/concepts/cp-tech-overview.html.md.erb
@@ -1,6 +1,6 @@
 ---
-title: Cloud Platform Overview
-last_reviewed_on: 2021-06-14
+title: Cloud Platform technical overview
+last_reviewed_on: 2021-06-28
 review_in: 3 months
 ---
 

--- a/source/documentation/concepts/what-can-be-hosted-on-the-cloud-platform.html.md.erb
+++ b/source/documentation/concepts/what-can-be-hosted-on-the-cloud-platform.html.md.erb
@@ -1,0 +1,23 @@
+---
+title: What can be hosted on the Cloud Platform
+last_reviewed_on: 2021-06-28
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+The MoJ Cloud Platform is for hosting "modern" applications.
+
+Ensure that your app:
+
+* can run in containers (Linux-based, Docker)
+* follows: [12 Factor App](https://12factor.net/)
+* uses backing services from AWS (which can be defined in Terraform)
+* its data is at OFFICIAL classification or [OFFICIAL-SENSITIVE](/documentation/concepts/official-sensitive.html), not anything higher
+* is secure - whilst CP environments are generally isolated, there is an element of sharing, so we expect applications to be kept [patched](https://ministryofjustice.github.io/security-guidance/vulnerability-scanning-and-patch-management-guide/) and follow [security guidance](https://ministryofjustice.github.io/security-guidance/)
+* doesn't require private network connections such as PSN (see: [the internet is ok](https://ministryofjustice.github.io/security-guidance/internet-v-psn/#internet--v--psn))
+
+Support for:
+
+* micro-service architecture - this is supported but not necessary for Cloud Platform. Traditional monoliths or n-tier archictures can be hosted. Just bear in mind 12 factor app: they need to be [stateless](https://12factor.net/processes) to scale horizontally and [disposible](https://12factor.net/disposability) to be efficiently herded across the platform.
+* serverless - Cloud Platform is fine for the occasional lambda function used as AWS glue-code. However Cloud Platform doesn't currently give a good developer experience for rapid iteration, so doesn't support full serverless architectures. Supporting this is something CP is considering.

--- a/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
@@ -12,7 +12,7 @@ review_in: 3 months
 
 The aim of this guide is to walkthrough the process of deploying an application into the Cloud Platform.
 
-Before working through this tutorial, we recommend reading this [cloud platform overview] page, which
+Before working through this tutorial, we recommend reading this [Cloud Platform tech overview] page, which
 provides a high-level view of the software development lifecycle on the cloud platform.
 
 This guide uses a pre-configured ["Hello World" application][rubyapp-github] as an example of how to deploy your own. This application merely returns a static HTML response, and has no dependencies. Later examples will use more representative applications.
@@ -448,5 +448,5 @@ Now, if you reload the browser page showing the 'Hello world' message from the a
 [ECR]: https://aws.amazon.com/ecr/
 [Cloud Platform CLI]: ../getting-started/cloud-platform-cli.html
 [custom-domain-guide]: ../other-topics/custom-domain-cert.html
-[cloud platform overview]: ../concepts/cp-overview.html
+[Cloud Platform tech overview]: ../concepts/cp-tech-overview.html
 [authenticated to the live-1 cluster]: ../getting-started/kubectl-config.html

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,27 +1,37 @@
 ---
-title: Cloud platform user guide
+title: Cloud Platform user guide
 last_reviewed_on: 2021-06-23
 review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
 
-## Who is this user guide for?
-
 This user guide is for service teams with applications deployed, or intending
-to deploy, to the Ministry of Justice Cloud Platform. The platform manages the
-infrastructure that your application runs on and provides tooling for teams to
-deploy and manage their applications on that infrastructure. See also: [About
-the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
+to deploy, to the Ministry of Justice Cloud Platform.
+
+## Cloud Platform's offering
+<!-- For users intending/evaluating whether they can use Cloud Platform -->
+
+The Cloud Platform manages the infrastructure that your application runs on and
+provides tooling for teams to deploy and manage their applications on that
+infrastructure.
+
+- [About the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
+- [What can be hosted on the Cloud Platform](documentation/concepts/what-can-be-hosted-on-the-cloud-platform.html)
+- [OFFICIAL SENSITIVE - can my service be hosted on the Cloud Platform?](documentation/concepts/official-sensitive.html)
 
 ## Quickstart
-- [Overview of the Cloud Platform](documentation/concepts/cp-overview.html)
+<!-- For developers, who want to dive in and achieve common basics, without reading too much -->
+
+- [Technical overview of the Cloud Platform](documentation/concepts/cp-tech-overview.html)
 - [The Cloud Platform CLI](documentation/getting-started/cloud-platform-cli.html)
 - [Deploy your first Hello World application](documentation/deploying-an-app/helloworld-app-deploy.html)
 - [Create a GOV.UK Prototype Kit site](documentation/getting-started/prototype-kit.html)
 - [Set up continuous deployment using GitHub Actions](documentation/deploying-an-app/github-actions-continuous-deployment.html)
 
 ## How-to guides
+<!-- For developers looking to do certain things with Cloud Platform -->
+
 - [How to use `kubectl` to connect to the cluster](documentation/getting-started/kubectl-config.html)
 - [Creating a Cloud Platform Environment](documentation/getting-started/env-create.html)
 - [Creating an ECR repository](documentation/getting-started/ecr-setup.html) for your docker images
@@ -32,11 +42,11 @@ the Cloud Platform](documentation/concepts/about-the-cloud-platform.html)
 - [Removing an unneeded namespace](documentation/deploying-an-app/cleaning-up.html)
 
 ## Concepts
+<!-- For developers looking to understand Cloud Platform -->
 
 - [Kubernetes](documentation/concepts/kubernetes.html)
 - [Deploying to the Cloud Platform](documentation/concepts/deploying.html)
 - [Migrate from Template Deploy](documentation/concepts/migrate-from-td.html)
-- [OFFICIAL SENSITIVE - can my service be hosted on the Cloud Platform?](documentation/concepts/official-sensitive.html)
 - [Security Controls on the Cloud Platform](documentation/concepts/security-controls.html)
 
 ## Tutorials


### PR DESCRIPTION
This is to be clear about expectations for apps that go on Cloud Platform.

Why? Because in our migration to EKS we are being clear that state should
not live in containers, and I think this must be the first time we've talked
about apps needing to be 12 Factor Apps. This should be part of the deal
when considering CP.

Also, Analytical Platform need to factor this into their thinking. And
Serverless is a recent topic that needs a bit of addressing.

Whilst doing this, I changed the index page a bit:
* "CP's offering" section, to house this new article. The 'About' page fits
  well here too. I think this stuff is important enough to be at the top of
  the index.
* Added comments to each section to start to think about who they are for and why,
  because the sections are a bit of a mess at the moment. This is to start
  the ball rolling.