### PR TITLE
Fix link check for recent change to Auth0 response

### DIFF
--- a/bin/check.sh
+++ b/bin/check.sh
@@ -24,7 +24,7 @@ MOJ_GITHUB=/https...github.com.ministryofjustice.*/
 # annoying warnings due to some of the gem dependencies using functions that
 # have been deprecated in current versions of ruby.
 bundle exec htmlproofer 2>&1 \
-  --http-status-ignore 0,429,403 \
+  --http-status-ignore 0,429,403,400 \
   --allow-hash-href \
   --url-ignore "${MOJ_GITHUB}" \
   --url-swap "https?\:\/\/user-guide\.cloud-platform\.service\.justice\.gov\.uk:" \


### PR DESCRIPTION
Link to alertmanager now returns 400 to the link checker: https://github.com/ministryofjustice/cloud-platform-user-guide/runs/2940445651?check_suite_focus=true#step:5:13

Clearly the link is going to have an error because it wants you to login.
But rather than 401, Auth0 now has a new cloudflare check on its
login page, which I guess checks to see you are a human or bot. This returns
400 error to the link-checker on occasions (not always). Reproducible with:

    curl -L -I https://alertmanager.cloud-platform.service.justice.gov.uk/