### PR TITLE
Add user guide entry to migrate to live cluster

### DIFF
--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -8,7 +8,7 @@ review_in: 3 months
 
 ## Introduction
 
-This document intends to act as a guide to helo you migrate your namespace from "Live-1" to "Live".
+This document intends to act as a guide to help you migrate your namespace from "Live-1" to "Live".
 
 ### Terms used in this document
 
@@ -28,9 +28,9 @@ You will be migrating your Cloud Platform namespace, all permissions and resourc
 
 There are just a few things you need to ensure before you migrate between clusters.
 
-- Ensure your containers are "stateless". During the transition between clusters, your pods will be running simultaniously between "Live" and "Live-1". Any state that your containers (inside the pod) store on disk or persistent volume (such as EBS) will not be copied to the new cluster.
+- Ensure your containers are "stateless". During the transition between clusters, your pods will be running simultaneously between "Live" and "Live-1". Any state that your containers (inside the pod) store on disk or persistent volume (such as EBS) will not be copied to the new cluster.
 
-- Check that multiple copies of your app can communicate simultaniously with AWS resources. These AWS resources will be shared between clusters. For example, your RDS instance will accept connections from pods in "Live" and "Live-1".
+- Check that multiple copies of your app can communicate simultaneously with AWS resources. These AWS resources will be shared between clusters. For example, your RDS instance will accept connections from pods in "Live" and "Live-1".
 
 If this is a concern or you'd like to check in advance, please feel free to contact the Cloud Platform team.
 
@@ -44,7 +44,7 @@ During the process of migration high velocity apps will be unable to deploy to "
 
 ## Step 2 - Amend your ingress resource
 
-To ensure that you can send traffic to both clusters simultaniously you must add an annotation to your `ingress` resource to allow traffic weighting.
+To ensure that you can send traffic to both clusters simultaneously you must add an annotation to your `ingress` resource to allow traffic weighting.
 
 This looks as follows:
 
@@ -102,6 +102,14 @@ It is advised to send between 1-10% of the traffic to the live cluster. Once the
 NOTE: If results are not successful within the live cluster, rollback the annotations to their initial state (0% weight).
 
 ## Step 9 - Cleanup old "Live-1" namespace
+
+Once you've migrated to the "Live" cluster you can remove your namespace from the ["Live-1"]() directory. This is as simple as running the command:
+
+```bash
+rm -rf ./namespaces/live-1.cloud-platform.service.justice.gov.uk/<my-namespace-name>
+```
+
+The deletion will need to be written back to the main branch, so create a Pull Request and have it approved by the Cloud Platform team.
 
 ## Links for the new cluster
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -36,29 +36,72 @@ If this is a concern or you'd like to check in advance, please feel free to cont
 
 ## How to migrate
 
+The rest of this document contains the steps required to perform the migration. This is very much a work in progress, so please leave feedback if you've either struggled to understand a step or feel it could be clarified further.
+
 ## Step 1 - Agree a time to perform the migration
+
+During the process of migration high velocity apps will be unable to deploy to "Live-1". You should speak to your team and agree a time and date to attempt to migrate your namespace. It's also recommended that you get familiar with migrating a non-production namespace before attempting prod.
 
 ## Step 2 - Amend your ingress resource
 
+To ensure that you can send traffic to both clusters simultaniously you must add an annotation to your `ingress` resource to allow traffic weighting.
+
+This looks as follows:
+
+```yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: $namespace-live-1-cluster
+    external-dns.alpha.kubernetes.io/aws-weight: "50"
+```
+
+(Note - Please change the `$namespace` value in the above example to the namespace you are migrating.)
+
+The idea behind the annotation is to control where the traffic is going. Using the above example 50% of the traffic will be sent to the ingress in the "Live-1" cluster. In a later step, we will create another resource in the "Live" cluster that will weight the traffic between the two clusters.
+
 ## Step 3 - Copy the namespace directory from "Live"-1 to "Live"
 
-## Step 4 - Autenticate to the new cluster
+Copy the [namespace]() directory from the [live-1.cloud-platform.service.justice.gov.uk]() parent directory to its sibling directory [live-1.cloud-platform.service.justice.gov.uk](). This change will need to reviewed by the Cloud Platform team. Create a pull request and wait for approval. An example can be seen [here]().
+
+## Step 4 - Authenticate to the "Live" cluster
+
+Grab a new set of credentials from [login.apps.live.cloud-platform.service.justice.gov.uk]().
+
+## Step 4 - Add a new ingress resource
+
+Create a duplicate ingress resource? How do we advise the user here?
 
 ## Step 5 - Create a new step to your deployment pipeline
 
+There are multi ways people are deploying their application, this guide will cover two of them:
+
 ### Deploy with GitHub Actions
+
+Add instructions for deploying to live with gha.
 
 ### Deploy with CircleCI
 
+Add instructions for deploying to live with circle.
+
 ## Step 6 - Trigger your pipeline
 
+Trigger your application pipeline. This is normally done manually or by a push to branch.
+
 ## Step 7 - Test your application
+
+Test your application is working on the new cluster by performing manual tests. How do we test this?
 
 ## Step 8 - Start sending real traffic
 
 ## Step 9 - Weight live traffic between "Live" and "Live-1"
 
 ## Step 10 - Cleanup old "Live-1" namespace
+
+## Links for the new cluster
+
+## How to roll back
 
 ## Troubleshooting
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -95,9 +95,13 @@ Test your application is working on the new cluster by performing manual tests. 
 
 ## Step 8 - Start sending real traffic
 
-## Step 9 - Weight live traffic between "Live" and "Live-1"
+Traffic flow is controlled by tweaking external-dns ingress annotation (`aws-weight`), used to determine the proportion of traffic sent to that ingress. Initially it is not expected to have any traffic because live’s ingresses have `external-dns.alpha.kubernetes.io/aws-weight: "0"`. By setting this value to 5% or 10% route53 will send real traffic to the application.
 
-## Step 10 - Cleanup old "Live-1" namespace
+We recommend setting any value between 1-10% of the traffic to the live cluster. Once traffic flows into live and the application behaves as expected you could set 100% of the traffic into live and 0% into live-1.
+
+NOTE: If results are not as expected on the live cluster, rollback the annotations to their initial state (0% weight).
+
+## Step 9 - Cleanup old "Live-1" namespace
 
 ## Links for the new cluster
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -6,17 +6,33 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
-## Overview
+## Introduction
+
+This document intends to act as a guide to helo you migrate your namespace from "Live-1" to "Live".
 
 ### Terms used in this document
 
-### Cluster names
+There are some confusing names and terms used in this document. Here are a few:
+- "Live-1" = The name of the current Cloud Platform (Kubernetes) cluster your namespace is deployed to.
+- "Live" = The name of a new Cloud Platform (EKS) cluster that you'll need to migrate to.
 
 ## Why should you migrate
 
+The Cloud Platform is a Kubernetes cluster deployed using a tool named kOps. When the Cloud Platform was conceived in 2017, Kubernetes management tools such as EKS (Elastic Kubernetes Service from AWS) and GKE (Google Kubernetes Engine) were in their infancy. An architecture decision record (ADR) was created with the understanding and acceptance of the extra management overhead and slightly slower release times. Since then, EKS has matured to a state where the benefits of running a multi-tenant cluster without the overhead of maintaining the control plane has become extremely attractive. If you wish to read more, please see this ADR.
+
 ## What are you migrating
 
+You will be migrating your Cloud Platform namespace, all permissions and resources in your namespace [directory](). This doesn't include AWS resources.
+
 ## Prerequisites for migration
+
+There are just a few things you need to ensure before you migrate between clusters.
+
+- Ensure your containers are "stateless". During the transition between clusters, your pods will be running simultaniously between "Live" and "Live-1". Any state that your containers (inside the pod) store on disk or persistent volume (such as EBS) will not be copied to the new cluster.
+
+- Check that multiple copies of your app can communicate simultaniously with AWS resources. These AWS resources will be shared between clusters. For example, your RDS instance will accept connections from pods in "Live" and "Live-1".
+
+If this is a concern or you'd like to check in advance, please feel free to contact the Cloud Platform team.
 
 ## How to migrate
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -95,11 +95,11 @@ Test your application is working on the new cluster by performing manual tests. 
 
 ## Step 8 - Start sending real traffic
 
-Traffic flow is controlled by tweaking external-dns ingress annotation (`aws-weight`), used to determine the proportion of traffic sent to that ingress. Initially it is not expected to have any traffic because live’s ingresses have `external-dns.alpha.kubernetes.io/aws-weight: "0"`. By setting this value to 5% or 10% route53 will send real traffic to the application.
+Traffic flow is controlled by tweaking external-dns ingress annotation (`aws-weight`), which is used to determine the proportion of traffic sent to that ingress. Initially it is not expected to have any traffic because live’s ingresses have `external-dns.alpha.kubernetes.io/aws-weight: "0"`. For example, by setting this value to 5, route53 will send 5% of real traffic to the application.
 
-We recommend setting any value between 1-10% of the traffic to the live cluster. Once traffic flows into live and the application behaves as expected you could set 100% of the traffic into live and 0% into live-1.
+It is advised to send between 1-10% of the traffic to the live cluster. Once the traffic flows into the live cluster and the application behaves as expected, you could send 100% of the traffic into live cluster and 0% into live-1 cluster.
 
-NOTE: If results are not as expected on the live cluster, rollback the annotations to their initial state (0% weight).
+NOTE: If results are not successful within the live cluster, rollback the annotations to their initial state (0% weight).
 
 ## Step 9 - Cleanup old "Live-1" namespace
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -1,0 +1,49 @@
+---
+title: Migrate to the "Live" cluster
+last_reviewed_on: 2021-07-20
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+## Overview
+
+### Terms used in this document
+
+### Cluster names
+
+## Why should you migrate
+
+## What are you migrating
+
+## Prerequisites for migration
+
+## How to migrate
+
+## Step 1 - Agree a time to perform the migration
+
+## Step 2 - Amend your ingress resource
+
+## Step 3 - Copy the namespace directory from "Live"-1 to "Live"
+
+## Step 4 - Autenticate to the new cluster
+
+## Step 5 - Create a new step to your deployment pipeline
+
+### Deploy with GitHub Actions
+
+### Deploy with CircleCI
+
+## Step 6 - Trigger your pipeline
+
+## Step 7 - Test your application
+
+## Step 8 - Start sending real traffic
+
+## Step 9 - Weight live traffic between "Live" and "Live-1"
+
+## Step 10 - Cleanup old "Live-1" namespace
+
+## Troubleshooting
+
+## Feedback welcome


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/3030 and relates to instructions for end users to migrate onto the new "live" cluster. The document isn't complete as there are multiple different issues/tickets to resolve. I suggest merging this PR into main and then allow those issues/tickets to pad out sections of the document as and when.