### PR TITLE
Update ingress external-dns annotation

### DIFF
--- a/source/documentation/deploying-an-app/github-actions-continuous-deployment.html.md.erb
+++ b/source/documentation/deploying-an-app/github-actions-continuous-deployment.html.md.erb
@@ -128,12 +128,14 @@ spec:
   selector:
     app: webserver
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: helloworld-nginx-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:
@@ -147,6 +149,7 @@ spec:
           serviceName: nginx-service
           servicePort: 8080
 ```
+(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 Deploy to the cluster like this:
 

--- a/source/documentation/deploying-an-app/github-actions-continuous-deployment.html.md.erb
+++ b/source/documentation/deploying-an-app/github-actions-continuous-deployment.html.md.erb
@@ -128,7 +128,7 @@ spec:
   selector:
     app: webserver
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: helloworld-nginx-ingress

--- a/source/documentation/deploying-an-app/github-actions-continuous-deployment.html.md.erb
+++ b/source/documentation/deploying-an-app/github-actions-continuous-deployment.html.md.erb
@@ -134,7 +134,7 @@ metadata:
   name: helloworld-nginx-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<environment-name>-<colour>
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
@@ -149,7 +149,7 @@ spec:
           serviceName: nginx-service
           servicePort: 8080
 ```
-(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
+(Note - Please change the `ingress-name` and `environment-name` values in the above example, you can get the `environment-name` value from your namespace label "cloud-platform.justice.gov.uk/environment-name". The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 Deploy to the cluster like this:
 

--- a/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
@@ -131,7 +131,7 @@ metadata:
   name: helloworld-rubyapp-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<environment-name>-<colour>
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
@@ -146,7 +146,7 @@ spec:
           serviceName: rubyapp-service
           servicePort: 4567
 ```
-(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
+(Note - Please change the `ingress-name` and `environment-name` values in the above example, you can get the `environment-name` value from your namespace label "cloud-platform.justice.gov.uk/environment-name". The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 This tells the cluster that our ingress should accept web traffic to the hostname we
 defined, and should route that traffic to port 4567 of the "service" called

--- a/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
@@ -125,7 +125,7 @@ This is how the YAML files link together:
 ### `ingress.yaml`
 
 ```Yaml
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: helloworld-rubyapp-ingress

--- a/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
@@ -125,10 +125,14 @@ This is how the YAML files link together:
 ### `ingress.yaml`
 
 ```Yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: helloworld-rubyapp-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:
@@ -142,6 +146,7 @@ spec:
           serviceName: rubyapp-service
           servicePort: 4567
 ```
+(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 This tells the cluster that our ingress should accept web traffic to the hostname we
 defined, and should route that traffic to port 4567 of the "service" called

--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -125,7 +125,7 @@ namespace where the certificate and key material will be stored.
        name: <my-ingress>
        namespace: <my-namespace>
        annotations:
-         kubernetes.io/ingress.class: <my-namespace>
+         kubernetes.io/ingress.class: nginx
          external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<environment-name>-<colour>
          external-dns.alpha.kubernetes.io/aws-weight: "100"
      spec:

--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -119,7 +119,7 @@ namespace where the certificate and key material will be stored.
 3. You will need to update your `Ingress` spec to include the new hostname.
 
    ```
-     apiVersion: networking.k8s.io/v1
+     apiVersion: networking.k8s.io/v1beta1
      kind: Ingress
      metadata:
        name: <my-ingress>

--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -119,13 +119,15 @@ namespace where the certificate and key material will be stored.
 3. You will need to update your `Ingress` spec to include the new hostname.
 
    ```
-     apiVersion: networking.k8s.io/v1beta1
+     apiVersion: networking.k8s.io/v1
      kind: Ingress
      metadata:
        name: <my-ingress>
        namespace: <my-namespace>
        annotations:
          kubernetes.io/ingress.class: <my-namespace>
+         external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+         external-dns.alpha.kubernetes.io/aws-weight: "100"
      spec:
        tls:
        - hosts:
@@ -149,6 +151,8 @@ namespace where the certificate and key material will be stored.
    +           serviceName: <my-svc>
    +           servicePort: 80
    ```
+
+(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 Once you've made the changes to your `Ingress`, the cluster (and more
 specifically, `external-dns`) will update the necessary records defined in it.

--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -126,7 +126,7 @@ namespace where the certificate and key material will be stored.
        namespace: <my-namespace>
        annotations:
          kubernetes.io/ingress.class: <my-namespace>
-         external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+         external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<environment-name>-<colour>
          external-dns.alpha.kubernetes.io/aws-weight: "100"
      spec:
        tls:
@@ -152,7 +152,7 @@ namespace where the certificate and key material will be stored.
    +           servicePort: 80
    ```
 
-(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
+(Note - Please change the `ingress-name` and `environment-name` values in the above example, you can get the `environment-name` value from your namespace label "cloud-platform.justice.gov.uk/environment-name". The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 Once you've made the changes to your `Ingress`, the cluster (and more
 specifically, `external-dns`) will update the necessary records defined in it.

--- a/source/documentation/other-topics/ip-filtering.html.md.erb
+++ b/source/documentation/other-topics/ip-filtering.html.md.erb
@@ -21,7 +21,7 @@ Allowed client IP source ranges can be specified using the nginx.ingress.kuberne
 An example configuration using `nginx.ingress.kubernetes.io/whitelist-source-range: 1.1.1.1/24,10.0.0.0/24`
 
    ```
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/source/documentation/other-topics/ip-filtering.html.md.erb
+++ b/source/documentation/other-topics/ip-filtering.html.md.erb
@@ -21,7 +21,7 @@ Allowed client IP source ranges can be specified using the nginx.ingress.kuberne
 An example configuration using `nginx.ingress.kubernetes.io/whitelist-source-range: 1.1.1.1/24,10.0.0.0/24`
 
    ```
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -29,6 +29,8 @@ metadata:
           {"apiVersion":"networking.k8s.io/v1beta1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.class":"nginx","nginx.ingress.kubernetes.io/whitelist-source-range":"1.1.1.1/24,10.0.0.0/24"},"name":"<my-ingress>","namespace":"<my-namespace>"},"spec":{"rules":[{"host":"my-app.apps.live-1.cloud-platform.service.justice.gov.uk","http":{"paths":[{"backend":{"serviceName":"<my-svc>","servicePort":3000},"path":"/"}]}}],"tls":[{"hosts":["my-app.apps.live-1.cloud-platform.service.justice.gov.uk"]}]}}
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/whitelist-source-range: 1.1.1.1/24,10.0.0.0/24
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
   creationTimestamp: 2019-03-21T14:26:31Z
   generation: 1
   name: <my-ingress>
@@ -50,6 +52,8 @@ status:
     ingress:
     - hostname: <hostname>
    ```
+(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
+
 Testing with the annotation set:
 
 ```

--- a/source/documentation/other-topics/ip-filtering.html.md.erb
+++ b/source/documentation/other-topics/ip-filtering.html.md.erb
@@ -29,7 +29,7 @@ metadata:
           {"apiVersion":"networking.k8s.io/v1beta1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.class":"nginx","nginx.ingress.kubernetes.io/whitelist-source-range":"1.1.1.1/24,10.0.0.0/24"},"name":"<my-ingress>","namespace":"<my-namespace>"},"spec":{"rules":[{"host":"my-app.apps.live-1.cloud-platform.service.justice.gov.uk","http":{"paths":[{"backend":{"serviceName":"<my-svc>","servicePort":3000},"path":"/"}]}}],"tls":[{"hosts":["my-app.apps.live-1.cloud-platform.service.justice.gov.uk"]}]}}
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/whitelist-source-range: 1.1.1.1/24,10.0.0.0/24
-    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<environment-name>-<colour>
     external-dns.alpha.kubernetes.io/aws-weight: "100"
   creationTimestamp: 2019-03-21T14:26:31Z
   generation: 1
@@ -52,7 +52,7 @@ status:
     ingress:
     - hostname: <hostname>
    ```
-(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
+(Note - Please change the `ingress-name` and `environment-name` values in the above example, you can get the `environment-name` value from your namespace label "cloud-platform.justice.gov.uk/environment-name". The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 Testing with the annotation set:
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -50,7 +50,7 @@ To ensure that you can send traffic to both clusters simultaneously you must add
 This looks as follows:
 
 ```yaml
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
@@ -80,7 +80,7 @@ Grab a new set of credentials from [login.live.cloud-platform.service.justice.go
 Create a new Ingress from the copy of "live-1" Ingress. Amend the `aws-weight` annotation to "0", this will not send any traffic to "live". In the later step, we start sending real traffic by tweaking external-dns ingress annotation (`aws-weight`)
 
 ```yaml
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -50,15 +50,15 @@ To ensure that you can send traffic to both clusters simultaneously you must add
 This looks as follows:
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: $namespace-live-1-cluster
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
     external-dns.alpha.kubernetes.io/aws-weight: "50"
 ```
 
-(Note - Please change the `$namespace` value in the above example to the namespace you are migrating.)
+(Note - Please change the `ingress-name` and `namespace-name` values in the above example to the ingress and namespace name you are migrating. The `colour` should be `blue` for ingress in live-1)
 
 The idea behind the annotation is to control where the traffic is going. Using the above example 50% of the traffic will be sent to the ingress in the "Live-1" cluster. In a later step, we will create another resource in the "Live" cluster that will weight the traffic between the two clusters.
 
@@ -80,13 +80,15 @@ Grab a new set of credentials from [login.live.cloud-platform.service.justice.go
 Create a new Ingress from the copy of "live-1" Ingress. Amend the `aws-weight` annotation to "0", this will not send any traffic to "live". In the later step, we start sending real traffic by tweaking external-dns ingress annotation (`aws-weight`)
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: $namespace-live-1-cluster
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
     external-dns.alpha.kubernetes.io/aws-weight: "0"
 ```
+
+(Note - Please change the `colour` to `green` for ingress in live)
 
 ## Step 6 - Create a new step to your deployment pipeline
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -54,11 +54,11 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<environment-name>-<colour>
     external-dns.alpha.kubernetes.io/aws-weight: "50"
 ```
 
-(Note - Please change the `ingress-name` and `namespace-name` values in the above example to the ingress and namespace name you are migrating. The `colour` should be `blue` for ingress in live-1)
+(Note - Please change the `ingress-name` and `environment-name` values in the above example, you can get the `environment-name` value from your namespace label "cloud-platform.justice.gov.uk/environment-name". The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 The idea behind the annotation is to control where the traffic is going. Using the above example 50% of the traffic will be sent to the ingress in the "Live-1" cluster. In a later step, we will create another resource in the "Live" cluster that will weight the traffic between the two clusters.
 
@@ -84,7 +84,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-<colour>
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<environment-name>-<colour>
     external-dns.alpha.kubernetes.io/aws-weight: "0"
 ```
 

--- a/source/documentation/other-topics/modsecurity.html.md.erb
+++ b/source/documentation/other-topics/modsecurity.html.md.erb
@@ -69,6 +69,8 @@ metadata:
   name: app-ingress
   annotations:
     kubernetes.io/ingress.class: "modsec01"
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<environment-name>-<colour>
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -85,7 +87,7 @@ spec:
           serviceName: app-service
           servicePort: 8080
 ```
-(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
+(Note - Please change the `ingress-name` and `environment-name` values in the above example, you can get the `environment-name` value from your namespace label "cloud-platform.justice.gov.uk/environment-name". The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 ### Logging
 

--- a/source/documentation/other-topics/modsecurity.html.md.erb
+++ b/source/documentation/other-topics/modsecurity.html.md.erb
@@ -63,7 +63,7 @@ The above annotation is optional, but it can be used to pass transactionIDs from
 Example:
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app-ingress
@@ -85,6 +85,7 @@ spec:
           serviceName: app-service
           servicePort: 8080
 ```
+(Note - Please change the `ingress-name` and `namespace-name` values in the above example. The `colour` should be `blue` for ingress in live-1 and `green` for ingress in EKS `live` cluster)
 
 ### Logging
 

--- a/source/documentation/other-topics/modsecurity.html.md.erb
+++ b/source/documentation/other-topics/modsecurity.html.md.erb
@@ -63,7 +63,7 @@ The above annotation is optional, but it can be used to pass transactionIDs from
 Example:
 
 ```yaml
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: app-ingress

--- a/source/documentation/other-topics/network-policy.html.md.erb
+++ b/source/documentation/other-topics/network-policy.html.md.erb
@@ -52,7 +52,7 @@ The policy below allows all traffic from namespaces which have a label called `c
 # allow-source-namespace.yaml
 ---
 kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: allow-source-namespace
   namespace: target-namespace

--- a/source/documentation/other-topics/network-policy.html.md.erb
+++ b/source/documentation/other-topics/network-policy.html.md.erb
@@ -52,7 +52,7 @@ The policy below allows all traffic from namespaces which have a label called `c
 # allow-source-namespace.yaml
 ---
 kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-source-namespace
   namespace: target-namespace


### PR DESCRIPTION
The external-dns annotations to be used for migrating to eks live cluster

This is related to:
https://github.com/ministryofjustice/cloud-platform/issues/3161