### PR TITLE
Add example of Circleci config file

### DIFF
--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -107,10 +107,7 @@ Once the service account is created, you can grab the ca.crt, token and cluster_
 
 You can use a separate pipeline to deploy in "live" or amend the existing pipeline to add additional steps to authenticate and deploy to "live"
 
-Click[HERE](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/main/.circleci/config.yml) for an example of a circleci config.yml file that builds an image, authenticates and deploys an application to both the `live-1` and `live` clusters in the same workflow. The application is deployed using [Kubernetes manifest files](https://github.com/ministryofjustice/cloud-platform-reference-app/tree/main/deploy/kubectl) and include a [unique ingress identifier](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/73b021b36a0cfee9b7363a119db92597e398641c/deploy/kubectl/live-1/ingress.yaml#L6) for each cluster and a [weighting](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/73b021b36a0cfee9b7363a119db92597e398641c/deploy/kubectl/live-1/ingress.yaml#L7) of 50/50.
-
-
-
+Click [HERE](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/main/.circleci/config.yml) for an example of a circleci config.yml file that builds an image, authenticates and deploys an application to both the "live-1" and "live" clusters in the same workflow. The application is deployed using [Kubernetes manifest files](https://github.com/ministryofjustice/cloud-platform-reference-app/tree/main/deploy/kubectl) and include a [unique ingress identifier](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/73b021b36a0cfee9b7363a119db92597e398641c/deploy/kubectl/live-1/ingress.yaml#L6) for each cluster and a [weighting](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/73b021b36a0cfee9b7363a119db92597e398641c/deploy/kubectl/live-1/ingress.yaml#L7) of 50/50 as mentioned in `Step 2 - Amend your ingress resource` of this document. 
 
 ## Step 7 - Trigger your pipeline
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -101,7 +101,7 @@ For teams using Github Actions as continuous deployment following [user guide][g
 
 ### Deploy with CircleCI
 
-For teams who use circleci for continuous deployment, you will see a new CircleCI service account created in "live" cluster after the namespace directory is copied from "Live"-1. This serviceaccount is created using the serviceaccount.yaml file in your namespace folder.
+For teams who use circleci for continuous deployment, you will see a new CircleCI service account created in "live" cluster after the namespace directory is copied from "Live"-1. This serviceaccount is created by either the serviceaccount.yaml or serviceaccount.tf file in your namespace folder.
 
 Once the service account is created, you can grab the ca.crt, token and cluster_name, to authenticate to the "live" cluster.
 

--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -101,11 +101,16 @@ For teams using Github Actions as continuous deployment following [user guide][g
 
 ### Deploy with CircleCI
 
-For teams who use circleci for continuous deployment, will see your new CircleCI service account created in "live" cluster after the namespace directory is copied from "Live"-1.
+For teams who use circleci for continuous deployment, you will see a new CircleCI service account created in "live" cluster after the namespace directory is copied from "Live"-1. This serviceaccount is created using the serviceaccount.yaml file in your namespace folder.
 
 Once the service account is created, you can grab the ca.crt, token and cluster_name, to authenticate to the "live" cluster.
 
-You can use a seperate pipeline to deploy in "live" or amend the existing pipeline to add additional steps to authenticate and deploy to "live"
+You can use a separate pipeline to deploy in "live" or amend the existing pipeline to add additional steps to authenticate and deploy to "live"
+
+Click[HERE](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/main/.circleci/config.yml) for an example of a circleci config.yml file that builds an image, authenticates and deploys an application to both the `live-1` and `live` clusters in the same workflow. The application is deployed using [Kubernetes manifest files](https://github.com/ministryofjustice/cloud-platform-reference-app/tree/main/deploy/kubectl) and include a [unique ingress identifier](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/73b021b36a0cfee9b7363a119db92597e398641c/deploy/kubectl/live-1/ingress.yaml#L6) for each cluster and a [weighting](https://github.com/ministryofjustice/cloud-platform-reference-app/blob/73b021b36a0cfee9b7363a119db92597e398641c/deploy/kubectl/live-1/ingress.yaml#L7) of 50/50.
+
+
+
 
 ## Step 7 - Trigger your pipeline
 


### PR DESCRIPTION
Add a link to the ref app with a circleci config file that deploys to both live and live-1 in the same workflow. 