### PR TITLE
Migration cross-dependencies are too hard to explain here, so ask CP team

### DIFF
--- a/source/documentation/other-topics/migrate-to-live.html.md.erb
+++ b/source/documentation/other-topics/migrate-to-live.html.md.erb
@@ -166,7 +166,7 @@ To migrate your namespace from "live-1" to "live" you'll need to copy your names
   cloud-platform environment migrate
   ```
 
-- Commit changes to your branch, and create a pull request.
+- Commit changes to your branch, and create a pull request. This will create your namespace in "live".
 
 The migrate command copies the folder. In some cases it makes minor changes to the terraform or alerts to you changes you need to make manually, as described in these points:
 
@@ -175,6 +175,8 @@ The migrate command copies the folder. In some cases it makes minor changes to t
 - If you have an Elasticsearch module, it adds an IRSA change, needed for EKS.
 
 - `Money to prisoners` and `Pathfinder to analytical platform` teams use kiam for [cross account IAM roles][iam-infra]: You'll need to use [IRSA][irsa] in EKS. These [roles][iam-infra] need to be defined inside  the [environments repo][env-repo] using the guidence [here][irsa-cross-account].
+
+- If your namespace has dependencies on another namespace (e.g. terraform in one namespace creates k8s resources in another namespace), please ask the CP team for advice about resolving it for your circumstance.
 
 If you want to skip any warnings and continue anyway, the cli has a `--skip-warnings` flag you can enable.
 


### PR DESCRIPTION
This is the text @poornima-krishnasamy and I came up with.

We think Step 3 is the best place for this, because in many circumstances they will hit an error on this step, when the terraform plan fails, trying to create a k8s resource in another namespace that doesn't exist. In the other circumstances, when the namespace expects a k8s resource to be there, that is created by another namespace, then the error will likely occur when a pod in this namespace runs, which will be discovered by the user sometime between Step 3 and Step 8 Testing the application. So putting this advice in Step 3 covers both circumstances best.