### PR TITLE
Revamp kubectl auth page

### DIFF
--- a/source/documentation/getting-started/ecr-setup.html.md.erb
+++ b/source/documentation/getting-started/ecr-setup.html.md.erb
@@ -25,8 +25,9 @@ You need to have the [Cloud Platform CLI] tool installed.
 2. Navigate to your namespace directory
 
     ```bash
-    $ cd namespaces/live-1.cloud-platform.service.justice.gov.uk/$your_service
+    $ cd namespaces/live.cloud-platform.service.justice.gov.uk/$your_service
     ```
+    (Adjust the command to reference `live` or `live-1`, depending on the cluster that your namespace is on)
 
 3. Use the CLI tool to create your ECR
 

--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -6,164 +6,184 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
-The aim of this guide is to help you install and configure `kubectl`, the official command-line tool for Kubernetes.
+This is a guide to installing and configuring `kubectl`, the official command-line tool for Kubernetes.
 
-`kubectl` is used to deploy and manage applications on Kubernetes and is fundamental for anyone who wants to interact with the Cloud Platform.
+`kubectl` is used to deploy and manage applications on Kubernetes. Cloud Platform users will often use it, in addition to the [Cloud Platform CLI](/documentation/getting-started/cloud-platform-cli.html).
 
-After working through this guide you should be able to use kubectl to query and update your namespace(s) on the Cloud Platform.
+After working through this guide you should be able to use kubectl to query and update all the kubernetes resources in your namespace(s) on the Cloud Platform.
 
 ## Installation
 
-Please read the [official documentation][kubectl-install] on how to install `kubectl`.
+To install `kubectl`, please follow the official docs: [Install kubectl][kubectl-install].
 
-### Before you begin
+### Kubectl version
 
-You must use a kubectl version that is within one minor version difference of your cluster. For example, a v1.15 client should work with v1.14, v1.15, and v1.16 master. 
-Check the current value in [the infrastructure repository] to avoid unforeseen issues.
+Choose a kubectl version that is within one minor version difference of your cluster. For example, kubectl v1.20 should work with a Kubernetes cluster at v1.19, v1.20, and v1.21. (Although in practice there are rarely problems with even newer kubectl versions.)
 
-During migration to `live` cluster and if you want to switch between `live-1` and `live` cluster, can use the kubectl version `v1.18`
+You can check the current cluster versions here:
+
+* [live-1][https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/kops/live-1.yaml#L254]
+* [live][https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf#L107]
+
+During [migration to `live` cluster], or if you want to be able to switch between `live-1` and `live` cluster, use kubectl version `v1.19`
 
 ## Authentication
 
-After installing kubectl, you need to authenticate to the Cloud Platform.
+Next you'll need to ensure your GitHub user is in the right organization and team, and then do authentication.
 
-To do this, you must have a GitHub account to which your `...@digital.justice.gov.uk` email address has been added.
+### GitHub setup
 
-The Cloud Platform uses GitHub for authentication and authorisation, and access to different namespaces (e.g. `pvb-production`, `cla-staging`) is granted according to GitHub team membership (e.g. 'PVB' and 'CLA' teams).
+The Cloud Platform uses GitHub for authentication and authorisation:
 
-Your account must be a member of the Ministry of Justice Organisation on GitHub. If you are not already in the organisation, you can add yourself (provided you have added your MoJ email address to your GitHub account) using [this link][github-sso].
+1. Your GitHub user must be a member of the [Ministry of Justice organisation](https://github.com/orgs/ministryofjustice/people). See: [MOJ Technical Guidance - Member of the MoJ organisation](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#member-of-the-moj-organisation) (Note: you can only join if your user has 2FA enabled and your `...@digital.justice.gov.uk` email address has been added to it)
 
-### How do I connect to the kubernetes cluster?
+2. Access to each Cloud Platform environment/namespace (e.g. `pvb-production`, `cla-staging`) is granted according to GitHub team membership (e.g. 'PVB' and 'CLA' teams). To check which team is authorized for a particular environment, look in the `00-namespace.yaml` e.g. [00-namespace.yaml](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-test/00-namespace.yaml#L14)
 
-We use [Auth0] to bridge between GitHub's [OAuth2], and [OIDC] authentication, which Kubernetes supports. [Kuberos] generates a config file, containing access credentials. You need to download this file and store it on your laptop, as `~/.kube/config`
+### Get a kubeconfig file
 
-1. Click on the login link
+You'll login to the cluster using GitHub, and it will provide you with a token file, which you'll save on your machine as `~/.kube/config`
 
-    For `live` cluster, use the link [login.live.cloud-platform.service.justice.gov.uk][authenticate-to-live-cluster] and for `live-1` cluster use the link [login.cloud-platform.service.justice.gov.uk][cp-login]
+For those interested in how it works: GitHub is being used as an OIDC provider. Once you've logged in to GitHub, it provides a token, which is a signed JWT containing your GitHub username and list of teams you're in. GitHub passes it to Auth0 (OIDC broker), which passes it to Cloud Platform's login/Kuberos app, which provides it to you in a 'kubeconfig' file, containing the cluster API URL and token. This kubeconfig will be used when you run kubectl, to authenticate with the Kubernetes cluster in Cloud Platform.
 
-2. Go through the 'Sign in with GitHub' process
+1. Browse to the login URL - choose the one corresponding to the cluster where your environment is:
 
-    NB: Be careful when you reach the authorization step:
+    * `live` cluster: <https://login.live.cloud-platform.service.justice.gov.uk/>
+    * `live-1` cluster: <https://login.cloud-platform.service.justice.gov.uk/>
+
+2. Select 'Sign in with GitHub'. (This page is hosted by Auth0.com)
+
+3. You're redirected to github.com and will need to login, if you've not done so already.
+
+4. GitHub asks if 'MOJ Cloud Platforms Auth0' may access your GitHub user details. Select "Authorize".
 
     ![GitHub Authorize MoJ](/images/github-authorize-moj-new.png)
 
-3. Authorise 'live-1/live:kubernetes' to access your 'justice-cloud-platform' tenant
-4. Use the 'Download Config File' button
-5. Rename the downloaded file to `~/.kube/config`
-6. Run this command:
+5. Auth0.com asks if 'live:kubernetes' app may access 'justice-cloud-platform account'. Select "Accept".
 
-```
-kubectl config use-context live-1.cloud-platform.service.justice.gov.uk
-```
+6. Select 'Download Config File'.
 
-For `live` cluster, run this command:
+7. Move the downloaded file to `~/.kube/config`:
 
-```
-kubectl config use-context live.cloud-platform.service.justice.gov.uk
-```
+   ```bash
+   mv kubecfg.yaml ~/.kube/config
+   ```
+
+   If you've already got a kubeconfig, you may want to replace it, or merge with it - see [Using multiple kubeconfigs](#using-multiple-kubeconfigs).
+
+8. Minimize the permissions on the file:
+
+   ```bash
+   chmod 600 ~/.kube/config
+   ```
+
+9. Tell kubectl to use this config. Pick the cluster, the same as you selected in Step 1:
+
+    * `live` cluster:
+
+      ```bash
+      kubectl config use-context live.cloud-platform.service.justice.gov.uk
+      ```
+
+    * `live-1` cluster:
+
+      ```bash
+      kubectl config use-context live-1.cloud-platform.service.justice.gov.uk
+      ```
 
 You should now be able to run `kubectl` commands. Try running `kubectl get namespaces` to list the namespaces in the cluster.
 
 #### Troubleshooting: "current" context
 
 If you see an error like this when executing `kubectl` commands:
-```
+
+```bash
 The connection to the server localhost:8080 was refused
 ```
 
-Check that your "current" context is set, by running:
+A common reason for this is that the "current" context has not been set. Check it by running:
 
-```
+```bash
 kubectl config get-contexts
 ```
 
-If the output looks like this (i.e. there is no `*` indicating that the live-1 context is set as the `current` context:
+If current context is set correctly, you'll see a `*`, like this:
 
-```
-CURRENT   NAME                                           CLUSTER                                        AUTHINFO                 NAMESPACE
-          live-1.cloud-platform.service.justice.gov.uk   live-1.cloud-platform.service.justice.gov.uk   <your github e-mail>
-```
-
-If the output looks like this (i.e. there is no `*` indicating that the live context is set as the `current` context:
-
-```
-CURRENT   NAME                                           CLUSTER                                        AUTHINFO                 NAMESPACE
-          live.cloud-platform.service.justice.gov.uk   live.cloud-platform.service.justice.gov.uk   <your github e-mail>
+```bash
+CURRENT   NAME                                         CLUSTER                                      AUTHINFO                 NAMESPACE
+*         live.cloud-platform.service.justice.gov.uk   live.cloud-platform.service.justice.gov.uk   <your github e-mail>
 ```
 
-Then you need to set the context with the `use-context` command mentioned above.
+If the `*` is missing, then you need to set the context with the `use-context` command mentioned above.
 
 ### Using multiple kubeconfigs
 
-During [migration from live-1 to live][migrate-to-live], you will have multiple kubeconfig files (one per cluster) but you may want to use them all at once, with kubectl that work with multiple contexts at once.
+You can have two kubeconfig files, corresponding to different clusters, which is useful during [migration from live-1 to live][migrate-to-live]. This is a guide to being able to manage multiple kubeconfigs, so you can conveniently switch the cluster that kubectl connects to.
 
-To do that, you need to [merge the kubeconfigs into a single file][kubectl-merge], following the steps outlined below. 
+Essentially we will [merge the kubeconfigs into a single file][kubectl-merge], and use `kubectl config use-context` to switch between them.
 
-Grab a new set of credentials for live from [login.live.cloud-platform.service.justice.gov.uk][authenticate-to-live-cluster].
+1. Assuming you already have a kubeconfig for live-1, download another kubeconfig for live from [login.live.cloud-platform.service.justice.gov.uk][authenticate-to-live-cluster].
 
-You'll download a new config.yaml. Copy that to your .kube folder:
+2. Move the kubeconfig to your .kube folder:
 
-```bash
-    mv ~/Downloads/config.yaml ~/.kube/config-live
-```
+    ```bash
+        mv ~/Downloads/kubecfg.yaml ~/.kube/config-live
+    ```
 
-Note: You have the same user but a different token for "live-1" and "live" kubeconfig, [merging][kubectl-merge] the two configs will only keep the user for the first one it encounters, to avoid that you will need to use a different "user" name in the "live-1" and "live" kubeconfig.
+3. Edit `~/.kube/config-live`, and change the username **in two places**, from `<firstname>.<lastname>@digital.justice.gov.uk` to `<firstname>.<lastname>@live`, as shown below:
 
-Amend the "user" in `config-live` as shown below
+    ```yaml
+    contexts:
+    - context:
+        cluster: live.cloud-platform.service.justice.gov.uk
+        user: <firstname>.<lastname>@live
+    name: live.cloud-platform.service.justice.gov.uk
+    current-context: ""
+    kind: Config
+    preferences: {}
+    users:
+    - name: <firstname>.<lastname>@live
+    ```
 
-```
-contexts:
-- context:
-    cluster: live.cloud-platform.service.justice.gov.uk
-    user: <firstname>.<lastname>@live
-  name: live.cloud-platform.service.justice.gov.uk
-current-context: ""
-kind: Config
-preferences: {}
-users:
-- name: <firstname>.<lastname>@live
+    Explanation: If we don't rename the username, then the merge will overwrite one of the them and their token, which is different between the clusters.
 
-```
+4. Copy your existing live-1 credentials into a separate file:
 
-Copy your existing live-1 credentials into a separate file:
+    ```bash
+        cp ~/.kube/config ~/.kube/config-live-1
+    ```
 
-```bash
-    cp ~/.kube/config ~/.kube/config-live-1
-```
+5. Edit `~/.kube/config-live-1`, and change the username in two places, from `<firstname>.<lastname>@digital.justice.gov.uk` to `<firstname>.<lastname>@live-1`, as shown below:
 
-Amend the "user" in `config-live-1` as shown below
+    ```yaml
+    contexts:
+    - context:
+        cluster: live-1.cloud-platform.service.justice.gov.uk
+        user: <firstname>.<lastname>@live-1
+    name: live-1.cloud-platform.service.justice.gov.uk
+    current-context: ""
+    kind: Config
+    preferences: {}
+    users:
+    - name: <firstname>.<lastname>@live-1
+    ```
 
-```
-contexts:
-- context:
-    cluster: live-1.cloud-platform.service.justice.gov.uk
-    user: <firstname>.<lastname>@live-1
-  name: live-1.cloud-platform.service.justice.gov.uk
-current-context: ""
-kind: Config
-preferences: {}
-users:
-- name: <firstname>.<lastname>@live-1
+6. [Merge][kubectl-merge] the two config files together into a new config file and replace your old config with the new merged config:
 
-```
-
-Then, run this command to [merge][kubectl-merge] the two config files together into a new config file and replace your old config with the new merged config.
-
-```
-KUBECONFIG=~/.kube/config-live-1:~/.kube/config-live kubectl config view --flatten > /tmp/config && mv /tmp/config ~/.kube/config
-```
+    ```bash
+    KUBECONFIG=~/.kube/config-live-1:~/.kube/config-live kubectl config view --flatten > /tmp/config && mv /tmp/config ~/.kube/config
+    ```
 
 Now using the single config file, you can switch between live-1 and live context
 
 For live-1:
 
-```
+```bash
 kubectl config use-context live-1.cloud-platform.service.justice.gov.uk
 ```
 
 For live:
 
-```
+```bash
 kubectl config use-context live.cloud-platform.service.justice.gov.uk
 ```
 
@@ -180,7 +200,6 @@ Once you are ready to deploy applications you will need to [create a namespace] 
 [Kuberos]: https://github.com/negz/kuberos
 [kubectl-cheatsheet]: https://kubernetes.io/docs/reference/kubectl/cheatsheet/
 [github-sso]: https://github.com/orgs/ministryofjustice/sso
-[cp-login]: https://login.cloud-platform.service.justice.gov.uk/
 [create a namespace]: /documentation/getting-started/env-create.html
 [the infrastructure repository]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/kops/live-1.yaml#L254
 [authenticate-to-live-cluster]: https://login.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
I've rewritten a lot in this page to try to improve understandability.

* clearly show the `live` and `live-1` commands side-by-side, by presenting them as bullet points.
* numbering the steps to setup GitHub, to help readers who skim the page
* added missing step during authentication: "4. GitHub asks if 'MOJ Cloud Platforms Auth0' may access your GitHub user details. Select "Authorize"."
* markdown lint fixes (pedantry basically...)