### PR TITLE
Fix formatting on kubectl page

### DIFF
--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -22,10 +22,10 @@ Choose a kubectl version that is within one minor version difference of your clu
 
 You can check the current cluster versions here:
 
-* [live-1][https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/kops/live-1.yaml#L254]
-* [live][https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf#L107]
+* [live-1 Kubernetes version](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/kops/live-1.yaml#L254)
+* [live Kubernetes version](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf#L30)
 
-During [migration to `live` cluster], or if you want to be able to switch between `live-1` and `live` cluster, use kubectl version `v1.19`
+During [migration to `live` cluster](/documentation/other-topics/migrate-to-live.html), or if you want to be able to switch between `live-1` and `live` cluster, use kubectl version `v1.19`
 
 ## Authentication
 
@@ -46,9 +46,8 @@ You'll login to the cluster using GitHub, and it will provide you with a token f
 For those interested in how it works: GitHub is being used as an OIDC provider. Once you've logged in to GitHub, it provides a token, which is a signed JWT containing your GitHub username and list of teams you're in. GitHub passes it to Auth0 (OIDC broker), which passes it to Cloud Platform's login/Kuberos app, which provides it to you in a 'kubeconfig' file, containing the cluster API URL and token. This kubeconfig will be used when you run kubectl, to authenticate with the Kubernetes cluster in Cloud Platform.
 
 1. Browse to the login URL - choose the one corresponding to the cluster where your environment is:
-
-    * `live` cluster: <https://login.live.cloud-platform.service.justice.gov.uk/>
-    * `live-1` cluster: <https://login.cloud-platform.service.justice.gov.uk/>
+   * `live` cluster: <https://login.live.cloud-platform.service.justice.gov.uk/>
+   * `live-1` cluster: <https://login.cloud-platform.service.justice.gov.uk/>
 
 2. Select 'Sign in with GitHub'. (This page is hosted by Auth0.com)
 
@@ -64,31 +63,29 @@ For those interested in how it works: GitHub is being used as an OIDC provider. 
 
 7. Move the downloaded file to `~/.kube/config`:
 
-   ```bash
-   mv kubecfg.yaml ~/.kube/config
-   ```
+    ```bash
+    mv kubecfg.yaml ~/.kube/config
+    ```
 
-   If you've already got a kubeconfig, you may want to replace it, or merge with it - see [Using multiple kubeconfigs](#using-multiple-kubeconfigs).
+    If you've already got a kubeconfig, you may want to replace it, or merge with it - see [Using multiple kubeconfigs](#using-multiple-kubeconfigs).
 
 8. Minimize the permissions on the file:
 
-   ```bash
-   chmod 600 ~/.kube/config
-   ```
+    ```bash
+    chmod 600 ~/.kube/config
+    ```
 
 9. Tell kubectl to use this config. Pick the cluster, the same as you selected in Step 1:
-
     * `live` cluster:
 
-      ```bash
-      kubectl config use-context live.cloud-platform.service.justice.gov.uk
-      ```
-
+        ```bash
+        kubectl config use-context live.cloud-platform.service.justice.gov.uk
+        ```
     * `live-1` cluster:
 
-      ```bash
-      kubectl config use-context live-1.cloud-platform.service.justice.gov.uk
-      ```
+        ```bash
+        kubectl config use-context live-1.cloud-platform.service.justice.gov.uk
+        ```
 
 You should now be able to run `kubectl` commands. Try running `kubectl get namespaces` to list the namespaces in the cluster.
 
@@ -126,7 +123,7 @@ Essentially we will [merge the kubeconfigs into a single file][kubectl-merge], a
 2. Move the kubeconfig to your .kube folder:
 
     ```bash
-        mv ~/Downloads/kubecfg.yaml ~/.kube/config-live
+    mv ~/Downloads/kubecfg.yaml ~/.kube/config-live
     ```
 
 3. Edit `~/.kube/config-live`, and change the username **in two places**, from `<firstname>.<lastname>@digital.justice.gov.uk` to `<firstname>.<lastname>@live`, as shown below:
@@ -149,7 +146,7 @@ Essentially we will [merge the kubeconfigs into a single file][kubectl-merge], a
 4. Copy your existing live-1 credentials into a separate file:
 
     ```bash
-        cp ~/.kube/config ~/.kube/config-live-1
+    cp ~/.kube/config ~/.kube/config-live-1
     ```
 
 5. Edit `~/.kube/config-live-1`, and change the username in two places, from `<firstname>.<lastname>@digital.justice.gov.uk` to `<firstname>.<lastname>@live-1`, as shown below:


### PR DESCRIPTION
Lots of whitespace fixes. The number gets messed up if the indents aren't right. And some bullets being indented too much meant they were rendered as code blocks.

Also the link for the k8s version was wrong.

I checked all these locally using `make preview`

(I didn't review the whole page for accuracy, though.)