### PR TITLE
Update prometheus webui link with live cluster link

### DIFF
--- a/source/documentation/monitoring-an-app/application-metrics.html.md.erb
+++ b/source/documentation/monitoring-an-app/application-metrics.html.md.erb
@@ -112,7 +112,7 @@ Create and apply a new resource `<application>-networkPolicy.yaml`, as below:
 
 We can now query our `/metric` endpoint using the Cloud Platform Prometheus.
 
-Head to [Cloud Platform Prometheus](https://prometheus.cloud-platform.service.justice.gov.uk/graph) and use the following promql query to view the application latency (remembering to change the namespace value):
+Head to Cloud Platform Prometheus [live cluster](https://prometheus.live.cloud-platform.service.justice.gov.uk/graph?g0.expr=&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h) / [live-1 cluster](https://prometheus.cloud-platform.service.justice.gov.uk/graph) and use the following promql query to view the application latency (remembering to change the namespace value):
 
 ```
 http_server_request_duration_seconds_sum{namespace="my-namespace"}


### PR DESCRIPTION
In the documentation, the link to the prometheus webui is to the **live-1** cluster. Add the **live** cluster link
to the documentation as another option.

hope this helps 🤞🏾 feel free to delete this PR and create one of your own because this change may not be worded in the best way.