### PR TITLE
Tweaks to guide to publish prototypes

### DIFF
--- a/source/documentation/getting-started/cloud-platform-cli.html.md.erb
+++ b/source/documentation/getting-started/cloud-platform-cli.html.md.erb
@@ -18,11 +18,14 @@ file).
 
 The CLI tool is a single binary: `cloud-platform`.
 
-If you're on a Mac, you can install it using homebrew:
+If you're on a Mac, you can install it using [Homebrew](https://brew.sh/):
 
 ```bash
-brew install ministryofjustice/cloud-platform-tap/cloud-platform-cli
+$ brew install ministryofjustice/cloud-platform-tap/cloud-platform-cli
 ```
+
+> Note: This only works if Homebrew is installed on your computer, please
+> visit Homebrew home page for up-to-date instructions on how to install it.
 
 Alternatively, install the binary into your $PATH (choose from the [GitHub releases] for your system):
 

--- a/source/documentation/getting-started/prototype-kit.html.md.erb
+++ b/source/documentation/getting-started/prototype-kit.html.md.erb
@@ -74,7 +74,25 @@ several files in a folder called:
 namespaces/live.cloud-platform.service.justice.gov.uk/[name you chose]
 ```
 
-Create a new branch, `git add` the new folder and then raise a pull request (PR).
+Create a new branch and add/commit the new folder to Git:
+
+```bash
+$ git checkout -b my-prototype
+$ git add .
+$ git commit -m "Added my-prototype prototype"
+```
+
+Push this branch to GitHub:
+
+```bash
+$ git push origin my-prototype
+```
+
+> Note: Please replace `my-prototype` in the commands above with the name you chose.
+
+And then raise a pull request (PR) by following the instructions that
+will appear on GitHub in the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments)
+repository.
 
 Once a member of the Cloud Platform team has approved your PR, merge it.
 


### PR DESCRIPTION
Added the explicit Git commands to run to create a new branch, commit
the changes and push to GitHub. Some designers may be less familiar
with the command line and Git.

In addition to this, page elaborates a bit on how to create a PR.

Similarly, in the Cloud Platform CLI page I added a note to made it clear
brew needs to be installed on your machine to run `brew install ...`.
Again, this may not be immediately apparent to some users (the note
refers them to Homebrew website for instructions on how to install it).