### PR TITLE
Add metadata key into ingress.yaml example

### DIFF
--- a/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
+++ b/source/documentation/deploying-an-app/helloworld-app-deploy.html.md.erb
@@ -127,6 +127,7 @@ This is how the YAML files link together:
 ```Yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+metadata:
   name: <ingress-name>
   namespace: <namespace-name>
   annotations:


### PR DESCRIPTION
The `metadata` key is missing from the ingress.yaml example, so this adds it in.