### PR TITLE
Update terraform.io links to use provider registry direct links

### DIFF
--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -174,7 +174,7 @@ based on your operating system and/or browser.
 [support-ticket]: http://goo.gl/msfGiS
 [wiki-domain-structure]: https://en.wikipedia.org/wiki/Domain_Name_System#Structure
 [wiki-nameservers]: https://en.wikipedia.org/wiki/Name_server#Authoritative_name_server
-[tf-route53-record]: https://www.terraform.io/docs/providers/aws/r/route53_record.html
+[tf-route53-record]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record
 [cert-guidance]: https://cert-manager.io/docs/concepts/certificate/
 [TLS]: https://en.wikipedia.org/wiki/Transport_Layer_Security
 [DNS zones]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html

--- a/source/documentation/other-topics/long-running-env-operations.html.md.erb
+++ b/source/documentation/other-topics/long-running-env-operations.html.md.erb
@@ -34,7 +34,7 @@ namespaces/live.cloud-platform.service.justice.gov.uk/mynamespace/APPLY_PIPELINE
 1. After your change has completed successfully, raise another PR to remove the `APPLY_PIPELINE_SKIP_THIS_NAMESPACE` file.
 
 [apply pipeline]: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live
-[Terraform state locking]: https://www.terraform.io/docs/language/state/locking.html
+[Terraform state locking]: https://www.terraform.io/language/state/locking
 [migrate-command]: /documentation/other-topics/migrate-to-live.html#step-3-migrate-your-namespace-environment-to-quot-live-quot
 [migration-live]: /documentation/other-topics/migrate-to-live.html#migrate-to-the-quot-live-quot-cluster
 [apply-pipeline]: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform

--- a/source/documentation/other-topics/route53-zone.html.md.erb
+++ b/source/documentation/other-topics/route53-zone.html.md.erb
@@ -142,4 +142,4 @@ Follow the [example-usage][aws_route53_record], to create different type of reco
 [env-repo]: https://github.com/ministryofjustice/cloud-platform-environments
 [aws-hosted-zone]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html
 [support ticket]: http://goo.gl/msfGiS
-[aws_route53_record]: https://www.terraform.io/docs/providers/aws/r/route53_record.html
+[aws_route53_record]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record


### PR DESCRIPTION
Terraform has moved provider resource documentation to their separate registry, so this PR updates those links.