### PR TITLE
Remove reference to Template Deploy documentation

### DIFF
--- a/source/documentation/reference/operational-processes.html.md.erb
+++ b/source/documentation/reference/operational-processes.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Cloud Platform Operational Processes
-last_reviewed_on: 2022-03-04
+last_reviewed_on: 2022-06-13
 review_in: 3 months
 ---
 
@@ -126,7 +126,5 @@ Support given will be on a best endeavours basis.
 All Cloud Platform documentation is openly available in Git repos stored on Github. The starting point for this documentation is the [Cloud Platform repo](https://github.com/ministryofjustice/cloud-platform).
 
 For users of the Cloud Platform there is the [Cloud Platform User Guide](https://user-guide.cloud-platform.service.justice.gov.uk). This guide is the "front door" to the Cloud Platform and contains concepts, tasks, walkthroughs and other information to help teams use the Cloud Platform.
-
-For our legacy systems based around Template Deploy, documentation lives in [Confluence](https://dsdmoj.atlassian.net/wiki/spaces/PLAT/overview). This documentation includes architecture, runbooks and common issues.
 
 [pagerduty]: https://www.pagerduty.com/


### PR DESCRIPTION
This PR removed the reference to Template Deploy (legacy platform) documentation. It's no longer relevant to users of the current platform as all services from the legacy platform were migrated a long time ago.