### PR TITLE
docs(prom): Update Prometheus metrics runbook for applications

### DIFF
--- a/source/documentation/monitoring-an-app/application-metrics.html.md.erb
+++ b/source/documentation/monitoring-an-app/application-metrics.html.md.erb
@@ -75,7 +75,7 @@ Create and apply your service monitor `<application>-serviceMonitor.yaml`, as be
    spec:
      selector:
        matchLabels:
-         app: rails-app-service
+         app: rails-app-service # this needs to match the label in the service under metadata:labels:app
      endpoints:
      - port: http # this is the port name you grabbed from your running service
        interval: 15s


### PR DESCRIPTION
Updating the User guide to add comment within the ServiceMonitor yaml configuration to make users aware that the matchLabels must match that in the Service or prometheus wont be able to find the target