### PR TITLE
Add note for when this process can be used.

### DIFF
--- a/source/documentation/getting-started/prototype-kit.html.md.erb
+++ b/source/documentation/getting-started/prototype-kit.html.md.erb
@@ -1,12 +1,14 @@
 ---
 title: Publish prototypes on the web
-last_reviewed_on: 2022-06-07
+last_reviewed_on: 2022-07-18
 review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
 
 You can share prototypes made with the [GOV.UK Prototype Kit] by publishing them on the web using an MoJ service called Cloud Platform.
+
+**Note - This process can only be used to deploy prototypes based on the [GOV.UK Prototype Kit]. This process will not work for any other types of apps e.g. Design History. If in any doubt please contact #ask-cloud-platform, or speak to your development team before you follow these instructions.** 
 
 ## Before you start
 


### PR DESCRIPTION
Due to issues of users trying to deploy non-prototypes using the prototype process we are adding a note at the start to clarify the the Prototype Process only works for Gov.uk Prototype Kit apps.