### PR TITLE
Add Grafana snapshot doc

### DIFF
--- a/source/documentation/other-topics/grafana-snapshots.html.md.erb
+++ b/source/documentation/other-topics/grafana-snapshots.html.md.erb
@@ -1,0 +1,37 @@
+---
+title: Publish Grafana Dashboard Snapshots
+last_reviewed_on: 2022-07-25
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+## Introduction
+
+You can publish a dashboard snapshot to users within and outside of the MOJ organisation.
+
+### Publish a Snapshots
+
+A dashboard snapshot shares an interactive dashboard publicly. Grafana strips sensitive data like queries (metric, template and annotation) and panel links, leaving only the visible metric data and series names embedded into your dashboard. Dashboard snapshots can be accessed by anyone with the link.
+
+You can publish snapshots to your local instance or to snapshots.raintank.io. The latter is a free service provided by Grafana Labs that allows you to publish dashboard snapshots to an external Grafana instance. `Anyone with the link can view it.` 
+
+You can set an expiration time if you want the snapshot removed after a certain time period. However, if you select the expire option to 'Never' and later decide you would like to stop sharing, you will need to create a [support ticket] with the Cloud Platform team to have the snapshot removed from public view. 
+
+#### Steps:
+
+* Click the `Share dashboard or panel` button next to the dashboard name on the dashboard page.
+
+![Dashboard share button](/images/grafana-snapshot1.png)
+
+* Select the `Snapshot` option.
+* Enter a name for the snapshot.
+* Select the `Expire` option.
+
+    Options are Never, 1 hour, 1 day and 7 days.
+
+* Click the `Local Snapshot` or `Publish to snapshot.raintank.io` button to publish.
+
+![Dashboard share page](/images/grafana-snapshot2.png)
+
+[support ticket]: http://goo.gl/msfGiS


### PR DESCRIPTION
This document adds steps for users to be able to share Grafana dashboard snapshots outside of the org