### PR TITLE
Move Technical Overview of the Cloud Platform and CI/CD tutorials to different sections

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -21,10 +21,8 @@ intending to deploy to, the Ministry of Justice's Cloud Platform.
 <!-- For users who want to achieve a simple task, such as connecting to the cluster or creating a namespace -->
 
 - [Using the Cloud Platform CLI](/documentation/getting-started/cloud-platform-cli.html)
-- [Technical overview of the Cloud Platform](documentation/concepts/cp-tech-overview.html)
 - [Deploy your first Hello World application](documentation/deploying-an-app/helloworld-app-deploy.html)
 - [Publish prototypes on the web](documentation/getting-started/prototype-kit.html)
-- [Set up continuous deployment using GitHub Actions](documentation/deploying-an-app/github-actions-continuous-deployment.html)
 
 ## How-to guides
 <!-- For developers looking to do certain things with Cloud Platform -->
@@ -49,6 +47,7 @@ intending to deploy to, the Ministry of Justice's Cloud Platform.
 ## Tutorials
  - [Deploying a `Hello World` application](documentation/deploying-an-app/helloworld-app-deploy.html)
  - [Deploying a multi-container application to the Cloud Platform](documentation/deploying-an-app/multicontainer-app-deploy.html)
+ - [Set up continuous deployment using GitHub Actions](documentation/deploying-an-app/github-actions-continuous-deployment.html)
 
 ### Deploying with Helm and CircleCI
  - [Prerequisite for deployment on the Cloud Platform](documentation/deploying-an-app/prerequisite.html)
@@ -112,6 +111,7 @@ intending to deploy to, the Ministry of Justice's Cloud Platform.
 - [Migrating from live-1 to live domain name](documentation/other-topics/migrating-from-live-1-domain-name.html)
 
 ## Reference
+- [Technical overview of the Cloud Platform](documentation/concepts/cp-tech-overview.html)
 - [Cloud Platform Operational Processes](documentation/reference/operational-processes.html)
 - [Kubernetes resources](documentation/reference/kubernetes.html)
 


### PR DESCRIPTION
This PR clears up the "Getting started" section on the user guide, by moving the Technical Overview to Reference material, and a CI/CD tutorial to the Tutorials section pending a refresh.