### PR TITLE
Fetch CLI documentation from CLI repository for inclusion in user guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 .DS_Store
 
 Staticfile.auth
+
+tmp/

--- a/fetch-cli-documentation.sh
+++ b/fetch-cli-documentation.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+tmp_dir=tmp/
+cli_doc_dir=source/documentation/reference/cli
+
+rm -rf $tmp_dir
+rm -rf $cli_doc_dir
+mkdir -p $cli_doc_dir
+
+git clone https://github.com/ministryofjustice/cloud-platform-cli tmp
+
+for f in tmp/doc/*.md; do
+  filename=$(basename "$f" .md)
+  { echo '---\ntitle: "Cloud Platform CLI documentation"\n---\n\n# <%= current_page.data.title %>\n\n'; cat "$f" | sed -e 's/\.md/\.html/g'; } > "$cli_doc_dir"/"$filename".html.md.erb
+done
+
+mv "$cli_doc_dir"/cloud-platform.html.md.erb "$cli_doc_dir"/index.html.md.erb
+
+rm -rf $tmp_dir

--- a/source/documentation/reference/cli/cloud-platform_cluster.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_cluster.html.md.erb
@@ -1,0 +1,28 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform cluster
+
+Cloud Platform cluster actions
+
+### Options
+
+```
+  -h, --help   help for cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.html)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform cluster recycle-node](cloud-platform_cluster_recycle-node.html)	 - recycle a node
+

--- a/source/documentation/reference/cli/cloud-platform_cluster_recycle-node.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_cluster_recycle-node.html.md.erb
@@ -1,0 +1,49 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform cluster recycle-node
+
+recycle a node
+
+```
+cloud-platform cluster recycle-node [flags]
+```
+
+### Examples
+
+```
+$ cloud-platform cluster recycle-node
+
+```
+
+### Options
+
+```
+      --aws-access-key string   aws access key to use
+      --aws-profile string      aws profile to use
+      --aws-region string       aws region to use (default "eu-west-2")
+      --aws-secret-key string   aws secret to use
+      --debug                   enable debug logging
+  -f, --force                   force the pods to drain (default true)
+  -h, --help                    help for recycle-node
+  -i, --ignore-label            whether to ignore the labels on the resource
+      --kubecfg string          path to kubeconfig file (default "/home/runner/.kube/config")
+  -n, --name string             name of the resource to recycle
+      --oldest                  whether to recycle the oldest node
+  -t, --timeout int             amount of time to wait for the drain command to complete (default 360)
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform cluster](cloud-platform_cluster.html)	 - Cloud Platform cluster actions
+

--- a/source/documentation/reference/cli/cloud-platform_completion.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_completion.html.md.erb
@@ -1,0 +1,37 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform completion
+
+Generate the autocompletion script for the specified shell
+
+### Synopsis
+
+Generate the autocompletion script for cloud-platform for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.html)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform completion bash](cloud-platform_completion_bash.html)	 - Generate the autocompletion script for bash
+* [cloud-platform completion fish](cloud-platform_completion_fish.html)	 - Generate the autocompletion script for fish
+* [cloud-platform completion powershell](cloud-platform_completion_powershell.html)	 - Generate the autocompletion script for powershell
+* [cloud-platform completion zsh](cloud-platform_completion_zsh.html)	 - Generate the autocompletion script for zsh
+

--- a/source/documentation/reference/cli/cloud-platform_completion_bash.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_completion_bash.html.md.erb
@@ -1,0 +1,56 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform completion bash
+
+Generate the autocompletion script for bash
+
+### Synopsis
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source <(cloud-platform completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	cloud-platform completion bash > /etc/bash_completion.d/cloud-platform
+
+#### macOS:
+
+	cloud-platform completion bash > $(brew --prefix)/etc/bash_completion.d/cloud-platform
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+cloud-platform completion bash
+```
+
+### Options
+
+```
+  -h, --help              help for bash
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform completion](cloud-platform_completion.html)	 - Generate the autocompletion script for the specified shell
+

--- a/source/documentation/reference/cli/cloud-platform_completion_fish.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_completion_fish.html.md.erb
@@ -1,0 +1,47 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform completion fish
+
+Generate the autocompletion script for fish
+
+### Synopsis
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	cloud-platform completion fish | source
+
+To load completions for every new session, execute once:
+
+	cloud-platform completion fish > ~/.config/fish/completions/cloud-platform.fish
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+cloud-platform completion fish [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for fish
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform completion](cloud-platform_completion.html)	 - Generate the autocompletion script for the specified shell
+

--- a/source/documentation/reference/cli/cloud-platform_completion_powershell.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_completion_powershell.html.md.erb
@@ -1,0 +1,44 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform completion powershell
+
+Generate the autocompletion script for powershell
+
+### Synopsis
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	cloud-platform completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+
+```
+cloud-platform completion powershell [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for powershell
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform completion](cloud-platform_completion.html)	 - Generate the autocompletion script for the specified shell
+

--- a/source/documentation/reference/cli/cloud-platform_completion_zsh.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_completion_zsh.html.md.erb
@@ -1,0 +1,58 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform completion zsh
+
+Generate the autocompletion script for zsh
+
+### Synopsis
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+	source <(cloud-platform completion zsh); compdef _cloud-platform cloud-platform
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	cloud-platform completion zsh > "${fpath[1]}/_cloud-platform"
+
+#### macOS:
+
+	cloud-platform completion zsh > $(brew --prefix)/share/zsh/site-functions/_cloud-platform
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+cloud-platform completion zsh [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for zsh
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform completion](cloud-platform_completion.html)	 - Generate the autocompletion script for the specified shell
+

--- a/source/documentation/reference/cli/cloud-platform_decode-secret.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_decode-secret.html.md.erb
@@ -1,0 +1,42 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform decode-secret
+
+Decode a kubernetes secret
+
+```
+cloud-platform decode-secret [flags]
+```
+
+### Examples
+
+```
+$ cloud-platform decode-secret -n mynamespace -s mysecret
+	
+```
+
+### Options
+
+```
+  -e, --export-aws-credentials   Export AWS credentials as shell variables
+  -h, --help                     help for decode-secret
+  -n, --namespace string         Namespace name
+  -r, --raw                      Output the raw secret, rather than prettyprinting
+  -s, --secret string            Secret name
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.html)	 - Multi-purpose CLI from the Cloud Platform team
+

--- a/source/documentation/reference/cli/cloud-platform_duplicate.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_duplicate.html.md.erb
@@ -1,0 +1,28 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform duplicate
+
+Cloud Platform duplicate resource
+
+### Options
+
+```
+  -h, --help   help for duplicate
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.html)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform duplicate ingress](cloud-platform_duplicate_ingress.html)	 - Duplicate ingress for the given ingress resource name and namespace
+

--- a/source/documentation/reference/cli/cloud-platform_duplicate_ingress.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_duplicate_ingress.html.md.erb
@@ -1,0 +1,50 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform duplicate ingress
+
+Duplicate ingress for the given ingress resource name and namespace
+
+### Synopsis
+
+Gets the ingress resource for the given name and namespace from the cluster,
+copies it, change the ingress name and external-dns annotations for the weighted policy and 
+apply the duplicated ingress to the same namespace.
+
+This command will access the cluster to get the ingress resource and to create the duplicate ingress.
+To access the cluster, it assumes that the user has either set the env variable KUBECONFIG to the filepath of kubeconfig or stored the file in the default location ~/.kube/config
+	
+
+```
+cloud-platform duplicate ingress <ingress name> [flags]
+```
+
+### Examples
+
+```
+$ cloud-platform duplicate ingress myingressname -n mynamespace
+
+
+```
+
+### Options
+
+```
+  -h, --help               help for ingress
+  -n, --namespace string   Namespace which you want to perform the duplicate resource
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform duplicate](cloud-platform_duplicate.html)	 - Cloud Platform duplicate resource
+

--- a/source/documentation/reference/cli/cloud-platform_environment.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment.html.md.erb
@@ -1,0 +1,34 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment
+
+Cloud Platform Environment actions
+
+### Options
+
+```
+  -h, --help   help for environment
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.html)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform environment bump-module](cloud-platform_environment_bump-module.html)	 - Bump all specified module versions
+* [cloud-platform environment create](cloud-platform_environment_create.html)	 - Create an environment
+* [cloud-platform environment ecr](cloud-platform_environment_ecr.html)	 - Add an ECR to a namespace
+* [cloud-platform environment prototype](cloud-platform_environment_prototype.html)	 - Create a gov.uk prototype kit site on the cloud platform
+* [cloud-platform environment rds](cloud-platform_environment_rds.html)	 - Add an RDS instance to a namespace
+* [cloud-platform environment s3](cloud-platform_environment_s3.html)	 - Add a S3 bucket to a namespace
+* [cloud-platform environment serviceaccount](cloud-platform_environment_serviceaccount.html)	 - Add a serviceaccount to a namespace
+

--- a/source/documentation/reference/cli/cloud-platform_environment_bump-module.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_bump-module.html.md.erb
@@ -1,0 +1,42 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment bump-module
+
+Bump all specified module versions
+
+```
+cloud-platform environment bump-module [flags]
+```
+
+### Examples
+
+```
+cloud-platform environments bump-module --module serviceaccount --module-version 1.1.1
+
+Would bump all users serviceaccount modules in the environments repository to the specified version.
+	
+```
+
+### Options
+
+```
+  -h, --help                    help for bump-module
+  -m, --module string           Module to upgrade the version
+  -v, --module-version string   Semantic version to bump a module to
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment](cloud-platform_environment.html)	 - Cloud Platform Environment actions
+

--- a/source/documentation/reference/cli/cloud-platform_environment_create.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_create.html.md.erb
@@ -1,0 +1,38 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment create
+
+Create an environment
+
+```
+cloud-platform environment create [flags]
+```
+
+### Examples
+
+```
+$ cloud-platform environment create
+
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment](cloud-platform_environment.html)	 - Cloud Platform Environment actions
+

--- a/source/documentation/reference/cli/cloud-platform_environment_ecr.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_ecr.html.md.erb
@@ -1,0 +1,35 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment ecr
+
+Add an ECR to a namespace
+
+### Examples
+
+```
+$ cloud-platform environment ecr create
+
+```
+
+### Options
+
+```
+  -h, --help   help for ecr
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment](cloud-platform_environment.html)	 - Cloud Platform Environment actions
+* [cloud-platform environment ecr create](cloud-platform_environment_ecr_create.html)	 - Create "resources/ecr.tf" terraform file for an ECR
+

--- a/source/documentation/reference/cli/cloud-platform_environment_ecr_create.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_ecr_create.html.md.erb
@@ -1,0 +1,31 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment ecr create
+
+Create "resources/ecr.tf" terraform file for an ECR
+
+```
+cloud-platform environment ecr create [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment ecr](cloud-platform_environment_ecr.html)	 - Add an ECR to a namespace
+

--- a/source/documentation/reference/cli/cloud-platform_environment_prototype.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_prototype.html.md.erb
@@ -1,0 +1,35 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment prototype
+
+Create a gov.uk prototype kit site on the cloud platform
+
+### Examples
+
+```
+$ cloud-platform environment prototype
+
+```
+
+### Options
+
+```
+  -h, --help   help for prototype
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment](cloud-platform_environment.html)	 - Cloud Platform Environment actions
+* [cloud-platform environment prototype create](cloud-platform_environment_prototype_create.html)	 - Create an environment to host gov.uk prototype kit site on the cloud platform
+

--- a/source/documentation/reference/cli/cloud-platform_environment_prototype_create.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_prototype_create.html.md.erb
@@ -1,0 +1,49 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment prototype create
+
+Create an environment to host gov.uk prototype kit site on the cloud platform
+
+### Synopsis
+
+
+Create a namespace folder and files in an existing prototype github repository to host a Gov.UK
+Prototype Kit website on the Cloud Platform.
+
+The namespace name should be your prototype github repository name:
+
+  https://github.com/ministryofjustice/[repository name]
+	
+
+```
+cloud-platform environment prototype create [flags]
+```
+
+### Examples
+
+```
+$ cloud-platform environment prototype create
+
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment prototype](cloud-platform_environment_prototype.html)	 - Create a gov.uk prototype kit site on the cloud platform
+

--- a/source/documentation/reference/cli/cloud-platform_environment_rds.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_rds.html.md.erb
@@ -1,0 +1,35 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment rds
+
+Add an RDS instance to a namespace
+
+### Examples
+
+```
+$ cloud-platform environment rds create
+
+```
+
+### Options
+
+```
+  -h, --help   help for rds
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment](cloud-platform_environment.html)	 - Cloud Platform Environment actions
+* [cloud-platform environment rds create](cloud-platform_environment_rds_create.html)	 - Create "resources/rds.tf" terraform file for an RDS instance
+

--- a/source/documentation/reference/cli/cloud-platform_environment_rds_create.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_rds_create.html.md.erb
@@ -1,0 +1,31 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment rds create
+
+Create "resources/rds.tf" terraform file for an RDS instance
+
+```
+cloud-platform environment rds create [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment rds](cloud-platform_environment_rds.html)	 - Add an RDS instance to a namespace
+

--- a/source/documentation/reference/cli/cloud-platform_environment_s3.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_s3.html.md.erb
@@ -1,0 +1,35 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment s3
+
+Add a S3 bucket to a namespace
+
+### Examples
+
+```
+$ cloud-platform environment s3 create
+
+```
+
+### Options
+
+```
+  -h, --help   help for s3
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment](cloud-platform_environment.html)	 - Cloud Platform Environment actions
+* [cloud-platform environment s3 create](cloud-platform_environment_s3_create.html)	 - Create "resources/s3.tf" terraform file for a S3 bucket
+

--- a/source/documentation/reference/cli/cloud-platform_environment_s3_create.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_s3_create.html.md.erb
@@ -1,0 +1,31 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment s3 create
+
+Create "resources/s3.tf" terraform file for a S3 bucket
+
+```
+cloud-platform environment s3 create [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment s3](cloud-platform_environment_s3.html)	 - Add a S3 bucket to a namespace
+

--- a/source/documentation/reference/cli/cloud-platform_environment_serviceaccount.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_serviceaccount.html.md.erb
@@ -1,0 +1,35 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment serviceaccount
+
+Add a serviceaccount to a namespace
+
+### Examples
+
+```
+$ cloud-platform environment serviceaccount
+
+```
+
+### Options
+
+```
+  -h, --help   help for serviceaccount
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment](cloud-platform_environment.html)	 - Cloud Platform Environment actions
+* [cloud-platform environment serviceaccount create](cloud-platform_environment_serviceaccount_create.html)	 - Creates a serviceaccount in your chosen namespace
+

--- a/source/documentation/reference/cli/cloud-platform_environment_serviceaccount_create.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_environment_serviceaccount_create.html.md.erb
@@ -1,0 +1,38 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform environment serviceaccount create
+
+Creates a serviceaccount in your chosen namespace
+
+```
+cloud-platform environment serviceaccount create [flags]
+```
+
+### Examples
+
+```
+$ cloud-platform environment serviceaccount create
+
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment serviceaccount](cloud-platform_environment_serviceaccount.html)	 - Add a serviceaccount to a namespace
+

--- a/source/documentation/reference/cli/cloud-platform_kubecfg.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_kubecfg.html.md.erb
@@ -1,0 +1,28 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform kubecfg
+
+Cloud Platform kubeconfig related commands
+
+### Options
+
+```
+  -h, --help   help for kubecfg
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.html)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform kubecfg id-token-claims](cloud-platform_kubecfg_id-token-claims.html)	 - Printing kubeconfig's ID token claims
+

--- a/source/documentation/reference/cli/cloud-platform_kubecfg_id-token-claims.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_kubecfg_id-token-claims.html.md.erb
@@ -1,0 +1,39 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform kubecfg id-token-claims
+
+Printing kubeconfig's ID token claims
+
+```
+cloud-platform kubecfg id-token-claims [flags]
+```
+
+### Examples
+
+```
+$ cloud-platform kubecfg id-token-claims
+
+```
+
+### Options
+
+```
+  -h, --help                help for id-token-claims
+  -f, --kubeconfig string   Supply a custom kubeconfig file (default "/home/runner/.kube/config")
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform kubecfg](cloud-platform_kubecfg.html)	 - Cloud Platform kubeconfig related commands
+

--- a/source/documentation/reference/cli/cloud-platform_prototype.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_prototype.html.md.erb
@@ -1,0 +1,28 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform prototype
+
+Cloud Platform Prototype actions
+
+### Options
+
+```
+  -h, --help   help for prototype
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.html)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform prototype deploy](cloud-platform_prototype_deploy.html)	 - Cloud Platform Environment actions
+

--- a/source/documentation/reference/cli/cloud-platform_prototype_deploy.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_prototype_deploy.html.md.erb
@@ -1,0 +1,28 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform prototype deploy
+
+Cloud Platform Environment actions
+
+### Options
+
+```
+  -h, --help   help for deploy
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform prototype](cloud-platform_prototype.html)	 - Cloud Platform Prototype actions
+* [cloud-platform prototype deploy create](cloud-platform_prototype_deploy_create.html)	 - Create the deployment files and github actions required to deploy in Cloud Platform
+

--- a/source/documentation/reference/cli/cloud-platform_prototype_deploy_create.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_prototype_deploy_create.html.md.erb
@@ -1,0 +1,52 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform prototype deploy create
+
+Create the deployment files and github actions required to deploy in Cloud Platform
+
+### Synopsis
+
+
+	Create the deployment files and github actions required to deploy the Prototype kit from a github repository in Cloud Platform.
+
+The files will be generated based on where the current local branch of the prototype github repository is pointed to:
+
+  https://[namespace name]-[branch-name].apps.live.cloud-platform.service.justice.gov.uk
+
+A continuous deployment workflow will be created in the github repository such
+that any changes to the branch are deployed to the cloud platform.
+	
+
+```
+cloud-platform prototype deploy create [flags]
+```
+
+### Examples
+
+```
+$ cloud-platform prototype deploy
+
+```
+
+### Options
+
+```
+  -h, --help                help for create
+  -s, --skip-docker-files   Whether to skip the files required to build the docker image i.e Dockerfile, .dockerignore, start.sh
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform prototype deploy](cloud-platform_prototype_deploy.html)	 - Cloud Platform Environment actions
+

--- a/source/documentation/reference/cli/cloud-platform_terraform.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_terraform.html.md.erb
@@ -1,0 +1,30 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform terraform
+
+Terraform actions.
+
+### Options
+
+```
+  -h, --help   help for terraform
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.html)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform terraform apply](cloud-platform_terraform_apply.html)	 - Execute terraform apply.
+* [cloud-platform terraform check-divergence](cloud-platform_terraform_check-divergence.html)	 - Terraform check-divergence check if there are drifts in the state.
+* [cloud-platform terraform plan](cloud-platform_terraform_plan.html)	 - Execute terraform plan.
+

--- a/source/documentation/reference/cli/cloud-platform_terraform_apply.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_terraform_apply.html.md.erb
@@ -1,0 +1,37 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform terraform apply
+
+Execute terraform apply.
+
+```
+cloud-platform terraform apply [flags]
+```
+
+### Options
+
+```
+      --aws-access-key-id string       Access key id of service account to be used by terraform
+      --aws-secret-access-key string   Secret access key of service account to be used by terraform
+      --dirs-file string               Required for bulk-plans, file path which holds directories where terraform plan is going to be executed
+  -d, --display-tf-output              Display or not terraform plan output (default true)
+  -h, --help                           help for apply
+  -v, --var-file string                tfvar to be used by terraform
+  -w, --workspace string               Default workspace where terraform is going to be executed (default "default")
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform terraform](cloud-platform_terraform.html)	 - Terraform actions.
+

--- a/source/documentation/reference/cli/cloud-platform_terraform_check-divergence.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_terraform_check-divergence.html.md.erb
@@ -1,0 +1,37 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform terraform check-divergence
+
+Terraform check-divergence check if there are drifts in the state.
+
+```
+cloud-platform terraform check-divergence [flags]
+```
+
+### Options
+
+```
+      --aws-access-key-id string       Access key id of service account to be used by terraform
+      --aws-secret-access-key string   Secret access key of service account to be used by terraform
+      --dirs-file string               Required for bulk-plans, file path which holds directories where terraform plan is going to be executed
+  -d, --display-tf-output              Display or not terraform plan output (default true)
+  -h, --help                           help for check-divergence
+  -v, --var-file string                tfvar to be used by terraform
+  -w, --workspace string               Default workspace where terraform is going to be executed (default "default")
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform terraform](cloud-platform_terraform.html)	 - Terraform actions.
+

--- a/source/documentation/reference/cli/cloud-platform_terraform_plan.html.md.erb
+++ b/source/documentation/reference/cli/cloud-platform_terraform_plan.html.md.erb
@@ -1,0 +1,37 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform terraform plan
+
+Execute terraform plan.
+
+```
+cloud-platform terraform plan [flags]
+```
+
+### Options
+
+```
+      --aws-access-key-id string       Access key id of service account to be used by terraform
+      --aws-secret-access-key string   Secret access key of service account to be used by terraform
+      --dirs-file string               Required for bulk-plans, file path which holds directories where terraform plan is going to be executed
+  -d, --display-tf-output              Display or not terraform plan output (default true)
+  -h, --help                           help for plan
+  -v, --var-file string                tfvar to be used by terraform
+  -w, --workspace string               Default workspace where terraform is going to be executed (default "default")
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform terraform](cloud-platform_terraform.html)	 - Terraform actions.
+

--- a/source/documentation/reference/cli/index.html.md.erb
+++ b/source/documentation/reference/cli/index.html.md.erb
@@ -1,0 +1,33 @@
+---
+title: "Cloud Platform CLI documentation"
+---
+
+# <%= current_page.data.title %>
+
+
+## cloud-platform
+
+Multi-purpose CLI from the Cloud Platform team
+
+```
+cloud-platform [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for cloud-platform
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform cluster](cloud-platform_cluster.html)	 - Cloud Platform cluster actions
+* [cloud-platform completion](cloud-platform_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cloud-platform decode-secret](cloud-platform_decode-secret.html)	 - Decode a kubernetes secret
+* [cloud-platform duplicate](cloud-platform_duplicate.html)	 - Cloud Platform duplicate resource
+* [cloud-platform environment](cloud-platform_environment.html)	 - Cloud Platform Environment actions
+* [cloud-platform kubecfg](cloud-platform_kubecfg.html)	 - Cloud Platform kubeconfig related commands
+* [cloud-platform prototype](cloud-platform_prototype.html)	 - Cloud Platform Prototype actions
+* [cloud-platform terraform](cloud-platform_terraform.html)	 - Terraform actions.
+


### PR DESCRIPTION
This PR includes a simplified `sh` script to fetch the cloud-platform-cli docs for inclusion within the user guide.