### PR TITLE
Remove stale "We're updating this documentation" note

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -6,8 +6,6 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
->From August 2022, we'll be rewriting and updating this documentation to make using the Cloud Platform simpler. If documentation is missing or isn't clear, please [let us know](mailto:platforms+user-guide@digital.justice.gov.uk).
-
 This user guide is for teams with applications or services deployed on, or
 intending to deploy to, the Ministry of Justice's Cloud Platform.
 


### PR DESCRIPTION
This PR removes the sale "We're updating this documentation" note, as updates are continuing but the main documentation has been split out into more readable groups.