### PR TITLE
Update the creating, upgrading RDS instances guides

### DIFF
--- a/source/documentation/deploying-an-app/relational-databases/create.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/create.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Creating a relational database
-last_reviewed_on: 2023-04-12
+last_reviewed_on: 2023-04-17
 review_in: 12 months
 ---
 
@@ -58,35 +58,37 @@ As a general rule of thumb, you should always use the latest generation you can.
 
 #### PostgreSQL
 
-| PostgreSQL version | Environment type | Instance type |
-|-|-|-|
-| **11.x to 12.6** | Non-production | `db.t3.micro` |
-|                  | Production     | `db.t3.small` |
-| **12.7 to 15.x** | Non-production | `db.t4g.micro` |
-|                  | Production     | `db.t4g.small` |
+| PostgreSQL version | Environment type | Instance type | Maximum allocated storage (GiB) |
+|-|-|-|-|
+| **11.x to 12.6** | Non-production | `db.t3.micro` | `"500"` |
+|                  | Production     | `db.t3.small` | `"10000"` |
+| **12.7 to 15.x** | Non-production | `db.t4g.micro` | `"500"` |
+|                  | Production     | `db.t4g.small` | `"10000"` |
 
 #### MariaDB
 
-| MariaDB version | Environment type | Instance type |
-|-|-|-|
-| **10.4.x to 10.6.x** | Non-production | `db.t4g.micro` |
-|                      | Production     | `db.t4g.small` |
+| MariaDB version | Environment type | Instance type | Maximum allocated storage (GiB) |
+|-|-|-|-|
+| **10.4.x to 10.6.x** | Non-production | `db.t4g.micro` | `"500"` |
+|                      | Production     | `db.t4g.small` | `"10000"` |
 
 #### MySQL
 
-| MySQL version | Environment type | Instance type |
-|-|-|-|
-| **8.0.28 to 8.0.x** | Non-production | `db.t4g.micro` |
-|                     | Production     | `db.t4g.small` |
+| MySQL version | Environment type | Instance type | Maximum allocated storage (GiB) |
+|-|-|-|-|
+| **8.0.28 to 8.0.x** | Non-production | `db.t4g.micro` | `"500"` |
+|                     | Production     | `db.t4g.small` | `"10000"` |
 
 If you find your Amazon RDS database is running out of CPU or memory, try changing the instance type (`micro`, `small`) to a larger instance type such as `medium`.
+
+If you find your Amazon RDS database is running out of storage, try changing your maximum allocated storage to a larger size. `micro` instance sizes are limited to a maximum of 6,114 GiB and `small` instance sizes are limited to a maximum of `16,384` GiB.
 
 ## Statistics
 
 At the time of writing, the following instance types were in use (along with how many) on the Cloud Platform. This can be useful to help you rightsize your instance type compared to other users of the Cloud Platform.
 
 <!--
-  Below was last updated 2023-04-12.
+  Below was last updated 2023-04-17.
 
   You can generate this yourself to replace by doing the following:
 
@@ -99,14 +101,14 @@ At the time of writing, the following instance types were in use (along with how
   4 "db.m6g.large"
   3 "db.m6g.xlarge"
   2 "db.r6g.large"
- 61 "db.t2.small"
+ 59 "db.t2.small"
   1 "db.t3.2xlarge"
   4 "db.t3.large"
  15 "db.t3.medium"
-131 "db.t3.small"
+129 "db.t3.small"
   4 "db.t3.xlarge"
   1 "db.t4g.large"
  10 "db.t4g.medium"
-  5 "db.t4g.micro"
- 93 "db.t4g.small"
+  4 "db.t4g.micro"
+ 97 "db.t4g.small"
 ```

--- a/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Upgrading a database version or changing the instance type
-last_reviewed_on: 2023-04-12
+last_reviewed_on: 2023-04-17
 review_in: 12 months
 ---
 
@@ -8,7 +8,7 @@ review_in: 12 months
 
 If you have a relational database in the Cloud Platform, you should keep it up to date and use the most cost effective instance type for your needs.
 
-AWS publishes an end-of-life schedule for major and minor versions of [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html), [MariaDB](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MariaDB.Concepts.VersionMgmt.html), and [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html) to help keep your database up to date.
+AWS publishes an end-of-life schedule for major and minor versions of [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html), [MariaDB](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MariaDB.Concepts.VersionMgmt.html), and [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html) to help you keep your database up to date.
 
 ## Things to note before upgrading a database version or changing the instance type
 
@@ -16,13 +16,9 @@ AWS publishes an end-of-life schedule for major and minor versions of [PostgreSQ
 
 >There is no rule of thumb to work out how long it will take, but tests show an empty database using a `db.t4g.micro` will take around 10 minutes.
 
->If you want to speed up your database version upgrade, you can temporarily change your instance type to provide more vCPU and memory to accomodate this. For example, changing a `db.t4g.micro` to a `db.t4g.small` will provide you with more vCPU and memory before upgrading your database version.
-
->If you do this, you should change it back to the original size (`micro`, `small`, `medium`, etc) after the upgrade is complete. This ensures that the increased cost is limited. See [changing your database instance type](#changing-your-database-instance-type) for details on how to do this.
-
 ## Upgrading to a new minor database version
 
->Note: This will cause some downtime. See [Things to note before upgrading your database](things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type) for further information.
+>Note: This will cause downtime. See [Things to note before upgrading your database](#things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type).
 
 To upgrade your minor database version, complete these three steps:
 
@@ -48,7 +44,7 @@ You should refer to the end-of-life schedule for major and minor versions for [P
 
 ## Upgrading to a new major database version
 
->Note: This will cause some downtime. See [Things to note before upgrading your database](things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type) for further information.
+>Note: This will cause downtime. See [Things to note before upgrading your database](#things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type).
 
 Please refer to the [Upgrading your RDS database: upgrading in-place](/documentation/other-topics/upgrade-rds-db.html#upgrading-in-place) guide for details on how to upgrade your database to a new major version.
 
@@ -58,23 +54,24 @@ You should refer to the major version upgrade paths for [PostgreSQL](https://doc
 
 ## Changing your database instance type
 
->Note: This will cause some downtime. See [Things to note before upgrading your database](things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type) for further information.
+>Note: This will cause downtime. See [Things to note before upgrading your database](#things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type).
 
 To change your database instance type, complete these three steps:
 
 1. Raise and merge a PR to tell the [apply pipeline to skip your namespace](/documentation/other-topics/long-running-env-operations.html#long-running-environments-operations)
 
-2. Raise and merge a PR that updates the `db_instance_class` attribute for your database, which is typically in `resources/rds.tf` in your namespace:
+2. Raise and merge a PR that updates the `db_instance_class` and `db_max_allocated_storage` attributes for your database, which are typically in `resources/rds.tf` in your namespace:
 
     ```hcl
     module "rds" {
       ...
-      db_instance_class = "db.t4g.small"
+      db_instance_class        = "db.t4g.micro"
+      db_max_allocated_storage = "500" # maximum storage for autoscaling
       ...
     }
     ```
 
-    The [Creating a relational database](/documentation/deploying-an-app/relational-databases/create.html#choosing-an-appropriate-instance-type) guide can help you decide which `db_instance_class` to use.
+    The [Creating a relational database](/documentation/deploying-an-app/relational-databases/create.html#choosing-an-appropriate-instance-type) guide can help you decide which `db_instance_class` and `db_max_allocated_storage` values to use.
 
     As soon as this PR is merged, the instance type change will begin.
 


### PR DESCRIPTION
This PR does a few things:

- adds the recommended and maximum limits for `maximum allocated storage` when used with instance sizes
- updates the statistics table
- fixes broken links
- removes outdated advice around changing your instance size _before_ a database upgrade, as it takes a similar amount of time to do it both ways, but this removes the amount of steps