### PR TITLE
Redis: update creation and upgrading guides

### DIFF
--- a/source/documentation/deploying-an-app/redis/create.html.md.erb
+++ b/source/documentation/deploying-an-app/redis/create.html.md.erb
@@ -1,16 +1,16 @@
 ---
 title: Creating a Redis cluster
-last_reviewed_on: 2023-07-13
+last_reviewed_on: 2023-07-23
 review_in: 12 months
 ---
 
 # <%= current_page.data.title %>
 
-To create a Redis cluster in the Cloud Platform, follow the [example guidance](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/tree/main/example) in the module.
+To create a Redis cluster in the Cloud Platform, follow the [example guidance](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/tree/main/examples) in the module.
 
 ## Choosing an appropriate instance type
 
-[ElastiCache for Redis](https://aws.amazon.com/elasticache/redis/) (which manages your Redis cluster) supports a wide range of instance types. Some instance types are considered "previous generation" and should not be used.
+[ElastiCache for Redis](https://aws.amazon.com/elasticache/redis/) (which manages your Redis cluster) supports a wide range of instance types. Some instance types are considered "previous generation" and must not be used.
 
 Instance types are named based on their family/purpose, generation, any additional capabilities, and size.
 
@@ -22,7 +22,7 @@ You can read the [supported node types for ElastiCache for Redis](https://docs.a
 
 You can use the table below to pick an appropriate instance type for your corresponding Redis version. This instance type should be suitable for most applications, environments, and how users of the Cloud Platform generally use ElastiCache for Redis.
 
-As a rule of thumb, you should always use the latest generation you can. If you are using an older version of ElastiCache for Redis, you should [upgrade your Redis version](/documentation/deploying-an-app/redis/upgrade.html#upgrading-a-redis-version) so you can use newer generations.
+You should always use the latest instance type you can. If you are using an older version of ElastiCache for Redis, you should [upgrade your Redis version](/documentation/deploying-an-app/redis/upgrade.html#upgrading-a-redis-version) so you can use newer instance types.
 
 | Redis version | Environment type | Instance type |
 |-|-|-|
@@ -39,7 +39,7 @@ At the time of writing, the following instance types were in use (along with how
 
 <!--
 
-Below was last updated 2023-07-13.
+Below was last updated 2023-07-23.
 
 You can generate this yourself to replace by doing the following:
 
@@ -48,10 +48,10 @@ aws elasticache describe-replication-groups --region=eu-west-2 | jq '.Replicatio
 -->
 
 ```
-   4 "cache.t2.medium"
+   3 "cache.t2.medium"
    5 "cache.t2.micro"
-  55 "cache.t2.small"
+  54 "cache.t2.small"
   12 "cache.t4g.medium"
- 101 "cache.t4g.micro"
-  59 "cache.t4g.small"
+ 104 "cache.t4g.micro"
+  60 "cache.t4g.small"
 ```

--- a/source/documentation/deploying-an-app/redis/upgrade.html.md.erb
+++ b/source/documentation/deploying-an-app/redis/upgrade.html.md.erb
@@ -1,12 +1,12 @@
 ---
 title: Upgrading a Redis version or changing the instance type
-last_reviewed_on: 2023-06-01
+last_reviewed_on: 2023-07-23
 review_in: 12 months
 ---
 
 # <%= current_page.data.title %>
 
-If you have a Redis cluster in the Cloud Platform, you should keep it up to date and use the most cost effective instance type for your needs.
+If you have a Redis cluster in the Cloud Platform, you must keep it up to date and use the most cost effective instance type for your needs.
 
 AWS publishes an [ElastiCache for Redis end-of-life schedule](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/deprecated-engine-versions.html) and [supported Redis versions](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) guide to help you keep up to date.
 
@@ -23,8 +23,8 @@ To upgrade your Redis cluster version, complete these three steps:
     ```hcl
     module "redis_cluster" {
       ...
-      engine_version       = "6.2"
-      parameter_group_name = "default.redis6.x"
+      engine_version       = "7.0"
+      parameter_group_name = "default.redis7"
       ...
     }
     ```
@@ -37,8 +37,6 @@ To upgrade your Redis cluster version, complete these three steps:
 
     | Version to upgrade to | engine_version | parameter_group_name |
     |-|-|-|
-    | Redis 5.0 | `5.0.6` | `default.redis5.0` |
-    | Redis 6.0 | `6.0` | `default.redis6.x` |
     | Redis 6.2 | `6.2` | `default.redis6.x` |
     | Redis 7.0 | `7.0` | `default.redis7` |
 
@@ -48,13 +46,14 @@ To upgrade your Redis cluster version, complete these three steps:
 
 Redis aims to maintain backwards compatibility when releasing a new major version. This means that you can upgrade your Redis cluster through multiple major versions in one upgrade step.
 
-For example, you can upgrade from ElastiCache for Redis `4.0.10` directly to ElastiCache for Redis `6.2.6` or ElastiCache for Redis `7.0`.
+For example, you can upgrade from ElastiCache for Redis `4.0.10` directly to ElastiCache for Redis `7.0`.
 
 | Current Redis version | You should upgrade to |
 |-|-|
-| 4.0.x | 6.2.x or 7.0 |
-| 5.0.x | 6.2.x or 7.0 |
-| 6.0.x | 6.2.x or 7.0 |
+| 4.0.x | 7.0 |
+| 5.0.x | 7.0 |
+| 6.0.x | 7.0 |
+| 6.2.x | 7.0 |
 
 ## Changing your Redis instance type
 
@@ -69,7 +68,7 @@ To change your Redis instance type, complete these three steps:
     ```hcl
     module "redis_cluster" {
       ...
-      node_type = "cache.t4g.small"
+      node_type = "cache.t4g.micro"
       ...
     }
     ```


### PR DESCRIPTION
This PR does a few things:

- fixes the example link
- removes uncertainty for requirements, i.e. changes `should` to `must` where there is a requirement to do something; e.g. keep something up to date
- simplifies the language surrounding "instance types" and "generations"
- updates the Upgrading example to use `Redis 7.0` instead of `6.2.x` to enable easier copy and pasting during an upgrade cycle, and the instance type to `cache.t4g.micro`
- removes `Redis 5.0` and `Redis 6.0` from the table of engine versions and parameter group names, as we've asked teams to upgrade to either `Redis 6.2.6` or `Redis 7.0` in the past, rather than `5.0` or `6.0`
- updates the upgrade matrix to point people towards `Redis 7.0` going forward, rather than `Redis 6.2.6`