### PR TITLE
Deprecating access keys: mark RDS Aurora as removed

### DIFF
--- a/source/documentation/other-topics/deprecating-long-lived-credentials.html.md.erb
+++ b/source/documentation/other-topics/deprecating-long-lived-credentials.html.md.erb
@@ -19,7 +19,7 @@ You should start using short-lived credentials as soon as you can. Long-lived cr
 | [cloud-platform-terraform-dms](https://github.com/ministryofjustice/cloud-platform-terraform-dms) | Starting replication tasks | 4th September 2023 | 1 |
 | [cloud-platform-terraform-dynamodb-cluster](https://github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster) | Accessing the database | 4th September 2023 | 19 |
 | [cloud-platform-terraform-elasticache-cluster](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster) | Rotating AUTH tokens | 4th September 2023 | 218 |
-| [cloud-platform-terraform-rds-aurora](https://github.com/ministryofjustice/cloud-platform-terraform-rds-aurora) | Taking manual backups | 4th September 2023 | 6 |
+| [cloud-platform-terraform-rds-aurora](https://github.com/ministryofjustice/cloud-platform-terraform-rds-aurora) | Taking manual backups | Removed | - |
 | [cloud-platform-terraform-rds-instance](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance) | Taking manual backups | 4th September 2023 | 400 |
 | [cloud-platform-terraform-s3-bucket](https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket) | Accessing the bucket | 4th September 2023 | 197 |
 | [cloud-platform-terraform-sns-topic](https://github.com/ministryofjustice/cloud-platform-terraform-sns-topic) | Accessing the topic | 4th September 2023 | 24 |


### PR DESCRIPTION
I've left the `last_reviewed_date` as 6th June, so we get an alert in Slack when we need to have removed all the access keys.