### PR TITLE
ECR long-lived credentials - delete long lived credentials in CI env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can run this website locally by running:
 make preview
 ```
 
-You can then browse to https://localhost:4567 to view the website.
+You can then browse to http://localhost:4567 to view the website.
 
 ## Updating documentation
 

--- a/source/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html.md.erb
+++ b/source/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html.md.erb
@@ -79,6 +79,13 @@ To use short-lived credentials in GitHub Actions, complete the following two ste
               IMAGE_TAG: ${{ github.sha }}
     ```
 
+3. Remove the long-term credentials from your repo's GitHub Action variables:
+
+    a) Browse to your GitHub repo
+    b) Select "Settings" and then "Actions secrets and variables"
+    c) Delete repository secrets: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+    d) Navigate back to your GitHub Actions and rerun a recent release workflow, to test it still works with the OIDC credentials
+
 ## Migrating to short-lived credentials for CircleCI
 
 If you use CircleCI to push your Docker image to a container repository on the Cloud Platform, you need to update your namespace and your CircleCI job.
@@ -201,3 +208,10 @@ To use short-lived credentials in CircleCI, complete the following four steps:
           - example:
               context: example-workflow
     ```
+
+5. Remove the long-term credentials from your repo's CircleCI Environment Variables.
+
+    a) Locate your repo's CircleCI project - browse to [CircleCI/ministryofjustice](https://app.circleci.com/projects/project-dashboard/github/ministryofjustice/) and then select your repo
+    b) Select "Project Settings" and then select in the sidebar "Environment Variables"
+    c) Delete variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+    d) Navigate back to your CircleCI project and rerun a recent release workflow, to test it still works with the OIDC credentials

--- a/source/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html.md.erb
+++ b/source/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html.md.erb
@@ -79,13 +79,6 @@ To use short-lived credentials in GitHub Actions, complete the following two ste
               IMAGE_TAG: ${{ github.sha }}
     ```
 
-3. Remove the long-term credentials from your repo's GitHub Action variables:
-
-    a) Browse to your GitHub repo
-    b) Select "Settings" and then "Actions secrets and variables"
-    c) Delete repository secrets: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-    d) Navigate back to your GitHub Actions and rerun a recent release workflow, to test it still works with the OIDC credentials
-
 ## Migrating to short-lived credentials for CircleCI
 
 If you use CircleCI to push your Docker image to a container repository on the Cloud Platform, you need to update your namespace and your CircleCI job.
@@ -211,7 +204,7 @@ To use short-lived credentials in CircleCI, complete the following four steps:
 
 5. Remove the long-term credentials from your repo's CircleCI Environment Variables.
 
-    a) Locate your repo's CircleCI project - browse to [CircleCI/ministryofjustice](https://app.circleci.com/projects/project-dashboard/github/ministryofjustice/) and then select your repo
-    b) Select "Project Settings" and then select in the sidebar "Environment Variables"
-    c) Delete variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-    d) Navigate back to your CircleCI project and rerun a recent release workflow, to test it still works with the OIDC credentials
+    1. Locate your repo's CircleCI project - browse to [CircleCI/ministryofjustice](https://app.circleci.com/projects/project-dashboard/github/ministryofjustice/) and then select your repo
+    2. Select "Project Settings" and then select in the sidebar "Environment Variables"
+    3. Delete variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+    4. Navigate back to your CircleCI project and rerun a recent release workflow, to test it still works with the OIDC credentials


### PR DESCRIPTION
Thought we might usefully add this step in. I found that the CCQ team had also independently failed to do this step, so it's not obvious to folks