### PR TITLE
Deprecating long-lived credentials for container repositories: remove `gha-` prefix

### DIFF
--- a/source/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html.md.erb
+++ b/source/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html.md.erb
@@ -71,8 +71,8 @@ To use short-lived credentials in GitHub Actions, complete the following two ste
 
           # Build and push a Docker image to the container repository
           - run: |
-              docker build -t $REGISTRY/$REPOSITORY:gha-$IMAGE_TAG .
-              docker push $REGISTRY/$REPOSITORY:gha-$IMAGE_TAG
+              docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+              docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
             env:
               REGISTRY: ${{ steps.login-ecr.outputs.registry }}
               REPOSITORY: ${{ vars.ECR_REPOSITORY }}


### PR DESCRIPTION
h/t @jemnery for spotting the difference between this workflow and the workflow used in the [authentication via GitHub Actions](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/create.html#github-actions-example-workflow) user guide.