### PR TITLE
Update relational databases guide with Postgres 16 information

### DIFF
--- a/source/documentation/deploying-an-app/relational-databases/create.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/create.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Creating a relational database
-last_reviewed_on: 2023-10-30
+last_reviewed_on: 2023-11-20
 review_in: 12 months
 ---
 
@@ -62,23 +62,21 @@ You should always use the latest instance type you can. If you are using an olde
 
 | PostgreSQL version | Environment type | Instance type | Maximum allocated storage (GiB) |
 |-|-|-|-|
-| **11.x to 12.6** | Non-production | `db.t3.micro` | `"500"` |
-|                  | Production     | `db.t3.small` | `"10000"` |
-| **12.7 to 15.x** | Non-production | `db.t4g.micro` | `"500"` |
+| **12.7 to 16.x** | Non-production | `db.t4g.micro` | `"500"` |
 |                  | Production     | `db.t4g.small` | `"10000"` |
 
 #### MariaDB
 
 | MariaDB version | Environment type | Instance type | Maximum allocated storage (GiB) |
 |-|-|-|-|
-| **10.4.x to 10.6.x** | Non-production | `db.t4g.micro` | `"500"` |
-|                      | Production     | `db.t4g.small` | `"10000"` |
+| **10.4.x to 10.11.x** | Non-production | `db.t4g.micro` | `"500"` |
+|                       | Production     | `db.t4g.small` | `"10000"` |
 
 #### MySQL
 
 | MySQL version | Environment type | Instance type | Maximum allocated storage (GiB) |
 |-|-|-|-|
-| **8.0.28 to 8.0.x** | Non-production | `db.t4g.micro` | `"500"` |
+| **8.0.25 to 8.0.x** | Non-production | `db.t4g.micro` | `"500"` |
 |                     | Production     | `db.t4g.small` | `"10000"` |
 
 If you find your Amazon RDS database is running out of CPU or memory, try changing the instance type (`micro`, `small`) to a larger instance type such as `medium`.
@@ -90,7 +88,7 @@ If you find your Amazon RDS database is running out of storage, try changing you
 At the time of writing, the following instance types were in use (along with how many) on the Cloud Platform. This can be useful to help you rightsize your instance type compared to other users of the Cloud Platform.
 
 <!--
-  Below was last updated 2023-10-30.
+  Below was last updated 2023-11-20.
 
   You can generate this yourself to replace by doing the following:
 
@@ -104,15 +102,15 @@ At the time of writing, the following instance types were in use (along with how
   4 "db.m6g.xlarge"
   2 "db.r6g.large"
   8 "db.serverless"
-  3 "db.t2.small"
+  1 "db.t2.small"
   7 "db.t3.medium"
   1 "db.t3.micro"
- 43 "db.t3.small"
-  3 "db.t3.xlarge"
+ 40 "db.t3.small"
+  2 "db.t3.xlarge"
   3 "db.t4g.2xlarge"
   6 "db.t4g.large"
  14 "db.t4g.medium"
-115 "db.t4g.micro"
-175 "db.t4g.small"
-  2 "db.t4g.xlarge"
+123 "db.t4g.micro"
+179 "db.t4g.small"
+  3 "db.t4g.xlarge"
 ```

--- a/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Upgrading a database version or changing the instance type
-last_reviewed_on: 2023-07-23
+last_reviewed_on: 2023-11-20
 review_in: 12 months
 ---
 
@@ -29,7 +29,7 @@ To upgrade your minor database version, complete these three steps:
     ```hcl
     module "rds" {
       ...
-      db_engine_version = "14.8" # the appropriate new minor version
+      db_engine_version = "16.1" # the appropriate new minor version
       ...
     }
     ```
@@ -46,7 +46,7 @@ You should refer to the end-of-life schedule for major and minor versions for [P
 
 >Note: This will cause downtime. See [Things to note before upgrading your database](#things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type).
 >
->Note: If you need to upgrade major versions more than once, e.g. from Postgres 11 to 14, and then 14 to 15, you **must** turn off `prepare_for_major_upgrade` (step 6) after each upgrade and then turn it back on (step 5). Otherwise, any upgrade after the first will fail.
+>Note: If you need to upgrade major versions more than once, e.g. from Postgres 12 to 14, and then 14 to 16, you **must** turn off `prepare_for_major_upgrade` (step 6) after each upgrade and then turn it back on (step 5). Otherwise, any upgrade after the first will fail.
 
 To upgrade your major database version, complete these eight steps:
 
@@ -82,8 +82,8 @@ To upgrade your major database version, complete these eight steps:
       ...
       prepare_for_major_upgrade = true
       db_engine                 = "postgres"
-      db_engine_version         = "14.8"
-      rds_family                = "postgres14"
+      db_engine_version         = "16.1"
+      rds_family                = "postgres16"
       ...
     }
     ```


### PR DESCRIPTION
This PR updates the create and upgrade relational databases guides to:

- remove old, unsupported versions of Postgres (11.x, 12.0 to 12.6)
- changes examples to use Postgres 16, as this is the latest version AWS now supports