### PR TITLE
:memo:user guide for blocking egress from namespace

### DIFF
--- a/source/documentation/other-topics/can-i-block-egress-traffic-to-the-internet-from-my-namespace.md.erb
+++ b/source/documentation/other-topics/can-i-block-egress-traffic-to-the-internet-from-my-namespace.md.erb
@@ -1,0 +1,38 @@
+---
+title: Can I block egress traffic to the internet from my namespace?
+last_reviewed_on: 2024-03-28
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+When creating a Cloud Platform environment namespace, by default the namespace allows egress traffic to the public internet. 
+This is by design to allows users to quickly get started to launch their application to reach the internet.
+
+If you have a requirement to block egress traffic from your namespace, you can append the following code to the `networkpolicty.yaml` file (replace `your-namespace` with the name of your namespace) This file is located in the root of your namespace directory.
+
+```
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: block-egress
+  namespace: your-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - {}
+```
+After applying this policy, egress traffic from all pods within the namespace will be blocked, while intra-namespace communication will still be allowed.
+
+Breakdown of the above yaml:
+- `podSelector: {}` selects all pods in the namespace.
+- `policyTypes: [Egress]` specifies that the policy applies only to egress traffic.
+- `egress: [{}]` specifies that all egress traffic is denied.
+
+
+
+
+


### PR DESCRIPTION
This adds a page to the CP user guide for users who require blocking egress from their namespace