### PR TITLE
replace technical-guidance links with new domain name

### DIFF
--- a/source/documentation/getting-started/prototype-kit.html.md.erb
+++ b/source/documentation/getting-started/prototype-kit.html.md.erb
@@ -208,4 +208,4 @@ Your namespace will be removed from the Cloud Platform.
 [github desktop]: https://docs.github.com/en/desktop
 [git client]: https://github.com/git-guides/install-git
 [cloud-platform prototype resources]: https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespace-resources-cli-template/resources/prototype/build
-[update your prototype kit]: https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit
+[update your prototype kit]: https://prototype-kit.service.gov.uk/docs/update-to-latest-version

--- a/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.html.md.erb
+++ b/source/documentation/monitoring-an-app/how-to-create-pingdom-checks.html.md.erb
@@ -82,7 +82,7 @@ Add the below 2 files in in the resources directory of your namespace in your [c
 
   [This](https://github.com/DrFaust92/terraform-provider-pingdom#pingdom-check) page explains all the attributes used in the check.
 
-  All resources, including Pingdom checks **must** be tagged and adhere to the technical guidance outlined [here](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html). Ensure your check has appropriate tags before submitting a pull request.
+  All resources, including Pingdom checks **must** be tagged and adhere to the technical guidance outlined [here](https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html). Ensure your check has appropriate tags before submitting a pull request.
 
 Once reviewed and merged to main, the [Apply Pipeline](/documentation/other-topics/apply-pipeline.html) will create your check in the MoJ Pingdom account.
 

--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -151,7 +151,7 @@ Once you've made the changes to your `Ingress`, the cluster (and more specifical
 
 
 [env-repo]: https://github.com/ministryofjustice/cloud-platform-environments/
-[naming-domains]: https://ministryofjustice.github.io/technical-guidance/documentation/standards/naming-domains.html
+[naming-domains]: https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-domains.html
 [creating-zone]: /documentation/other-topics/route53-zone.html#creating-a-route-53-hosted-zone
 [support-ticket]: https://goo.gl/msfGiS
 [wiki-domain-structure]: https://en.wikipedia.org/wiki/Domain_Name_System#Structure

--- a/source/documentation/reference/getting-help.html.md.erb
+++ b/source/documentation/reference/getting-help.html.md.erb
@@ -52,4 +52,4 @@ We can also help you determine [how to host your service] and whether the Cloud 
 
 [#ask-cloud-platform]: https://mojdt.slack.com/messages/C57UPMZLY
 [support-ticket]: https://goo.gl/msfGiS
-[how to host your service]: https://ministryofjustice.github.io/technical-guidance/documentation/standards/hosting.html#how-to-host-services
+[how to host your service]: https://technical-guidance.service.justice.gov.uk/documentation/standards/hosting.html#how-to-host-services

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -183,9 +183,9 @@ intending to deploy to, the Ministry of Justice's Cloud Platform.
 ### Kubernetes
 <!-- For users who want to understand Kubernetes specifics and its application to the Cloud Platform -->
 
-The Cloud Platform [currently uses Kubernetes v1.26](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf#L37-L42).
+The Cloud Platform [currently uses Kubernetes v1.27](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf#L37-L42).
 
-- [Official Kubernetes v1.26 documentation](https://v1-25.docs.kubernetes.io/docs/home/)
+- [Official Kubernetes v1.27 documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/)
 - [Namespace/Container Resource Limits](documentation/concepts/namespace-limits.html)
 - [Kubectl quick reference](documentation/other-topics/quick-reference.html)
 - [Troubleshooting guide](documentation/other-topics/troubleshooting.html)


### PR DESCRIPTION
Replace `ministryofjustice.github.io/technical-guidance` links with new `technical-guidance.service.justice.gov.uk` address

Update other broken links