### PR TITLE
Add join github service link

### DIFF
--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -39,8 +39,10 @@ You will need to:
 
 You can request access to the `ministryofjustice` GitHub organisation by:
 
-- [contacting the Operations Engineering team](https://operations-engineering.service.justice.gov.uk/#how-to-contact-us), or
+- using the [Join GitHub](https://join-github.service.justice.gov.uk/) service, or
 - getting your line manager to submit a ServiceNow request under the "GitHub for D&T staff - Add/Amend/Remove" item
+
+For any issues using the [Join GitHub](https://join-github.service.justice.gov.uk/) service, please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)
 
 ### Joining the correct GitHub teams
 


### PR DESCRIPTION
This PR updates the following document with a link to the Join GitHub service:

- [Connecting to the Cloud Platform’s Kubernetes cluster](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#joining-the-github-organisation)