### PR TITLE
Update example yaml for HorizontalPodAutoscaler

### DIFF
--- a/source/documentation/concepts/deploying.html.md.erb
+++ b/source/documentation/concepts/deploying.html.md.erb
@@ -145,12 +145,18 @@ spec:
     name: my-app-name
   minReplicas: 1
   maxReplicas: 5
-  targetCPUUtilizationPercentage: 95
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 95
 ```
 
 The above manifest will ensure a minimum of 1 replica is available for the deployment called my-app-name, but will increase replicas up to 5 when the CPU utilization is above 95%.
 
-To configure what value to set for `targetCPUUtilizationPercentage` depends on resource limits set up in your namespace and how much the actual pods consume.
+To configure what value to set for `averageUtilization` depends on resource limits set up in your namespace and how much the actual pods consume.
 This [limitrange file] defines the defaults we assign to new namespaces.
 
 - Check how much defaults is set for your namespace
@@ -160,7 +166,7 @@ This [limitrange file] defines the defaults we assign to new namespaces.
 kubectl top pods -n <namespace>
 ```
 If your namespace `defaultRequest.cpu : 10m` and you pods consumes `8m` wihtout any traffic, then the usual CPUUtilizationPercentage is 80%.
-The pods doesnot need scaling until it reaches 95% of the `defaultRequest.cpu` which is already reserved for each of the containers. Hence the `targetCPUUtilizationPercentage` can be set as 95%.
+The pods doesnot need scaling until it reaches 95% of the `defaultRequest.cpu` which is already reserved for each of the containers. Hence the `averageUtilization` can be set as 95%.
 
 Run the following command to apply:
 


### PR DESCRIPTION
These docs referenced targetCPUUtilizationPercentage, but this is no longer valid in v2 of HorizontalPodAutoscaler.

This is documented in https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics

> the targetCPUUtilizationPercentage field has been replaced with an array called metrics.