### PR TITLE
:recycle: Updated Instructions for Joining GitHub

### DIFF
--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -37,7 +37,7 @@ You will need to:
 
 ### Joining the GitHub organisation
 
-If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can simply join via [SSO](https://github.com/orgs/ministryofjustice/sso) to join.
+If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can simply join via [SSO](https://github.com/orgs/ministryofjustice/sso).
 For more information, please refer to the [Operations Engineering user guide](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojgithubenterprise.html).
 
 For any issues, or if you are unable to join via SSO, please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)

--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -37,11 +37,8 @@ You will need to:
 
 ### Joining the GitHub organisation
 
-You can request access to the `ministryofjustice` GitHub organisation by:
-
-- Using the [Join GitHub](https://join-github.service.justice.gov.uk/) service, or...
-- If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can use
-[SSO](https://github.com/orgs/ministryofjustice/sso) to join.
+If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can simply join via [SSO](https://github.com/orgs/ministryofjustice/sso) to join.
+For more information, please refer to the [Operations Engineering user guide](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojgithubenterprise.html).
 
 For any issues using the [Join GitHub](https://join-github.service.justice.gov.uk/) service, please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)
 

--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -40,7 +40,7 @@ You will need to:
 If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can simply join via [SSO](https://github.com/orgs/ministryofjustice/sso) to join.
 For more information, please refer to the [Operations Engineering user guide](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojgithubenterprise.html).
 
-For any issues using the [Join GitHub](https://join-github.service.justice.gov.uk/) service, please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)
+For any issues, or if you are unable to join via SSO, please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)
 
 ### Joining the correct GitHub teams
 

--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -39,8 +39,9 @@ You will need to:
 
 You can request access to the `ministryofjustice` GitHub organisation by:
 
-- using the [Join GitHub](https://join-github.service.justice.gov.uk/) service, or
-- getting your line manager to submit a ServiceNow request under the "GitHub for D&T staff - Add/Amend/Remove" item
+- Using the [Join GitHub](https://join-github.service.justice.gov.uk/) service, or...
+- If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can use
+[SSO](https://github.com/orgs/ministryofjustice/sso) to join.
 
 For any issues using the [Join GitHub](https://join-github.service.justice.gov.uk/) service, please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)
 


### PR DESCRIPTION
## 👀 Purpose

To keep users updated on the new SSO option for joining the `ministryofjustice` GitHub organisation.

## ♻️ What's Changed

- Removed the instructions on raising a request through ServiceNow, as this is no longer needed.
- Added instructions pointing the user to login through SSO.

## 📝 Notes

Marking as a draft for now until the change has taken effect.