### PR TITLE
🩹 changing offending text to fix search function

### DIFF
--- a/source/documentation/other-topics/rotate-tokens-keys.html.md.erb
+++ b/source/documentation/other-topics/rotate-tokens-keys.html.md.erb
@@ -134,7 +134,7 @@ In cases where you have a need for creating and storing AWS Access keys as Kuber
         "data": {
             "access_key_id": "XXXXXXX",
             "auth_token": "XXXXXXXXXXX",
-            "member_clusters": "[\"cp-1111111-001\",\"cp-222222222-002\"]",
+            "member_clusters": "[\"cp-1111111-111\",\"cp-222222222-222\"]",
             "primary_endpoint_address": "master.cp-1111111.XXXX.XXX.cache.amazonaws.com"
             "replication_group_id": "cp-1111111",
             "secret_access_key": "XXXXXXX"


### PR DESCRIPTION
This PR _fixes_ the search function in the [CP User Guide](https://user-guide.cloud-platform.service.justice.gov.uk/). 

The underlying [Javascript app running the tech docs](https://github.com/alphagov/tech-docs-gem) is not able to render search on any words featured on this [page](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rotate-tokens-keys.html), due the the following offending line which is an example code in the user guide:
`"member_clusters": "[\"cp-1111111-001\",\"cp-222222222-002\"]",`

The example code is now changed to the following which the search is able to render: 
`"member_clusters": "[\"cp-1111111-111\",\"cp-222222222-222\"]",`

Full issue and troubleshooting steps explained in [User Guide Search Bar Issue: Queries Not Returning Results, Returning Blank/Error Pages](https://github.com/ministryofjustice/cloud-platform/issues/6132)