### PR TITLE
docs: Fix up broken reference

### DIFF
--- a/source/documentation/other-topics/troubleshooting.html.md.erb
+++ b/source/documentation/other-topics/troubleshooting.html.md.erb
@@ -278,7 +278,7 @@ Possible causes include:
 
     Sometimes browser caching seems to cause problems with the authentication process, and using an incognito browser window usually resolves the problem.
 
-[application logging]: /documentation/logging-an-app/access-logs.html#accessing-application-log-data
+[application logging]: /documentation/logging-an-app/access-logs-os.html
 [visual guide]: https://learnk8s.io/troubleshooting-deployments
 [re-authenticate]: /documentation/getting-started/kubectl-config.html#authenticating-with-the-cloud-platform-39-s-kubernetes-cluster
 [token-groups]: /documentation/other-topics/check-id-token.html


### PR DESCRIPTION
Fix below error in user guide
```
* At ./docs/documentation/other-topics/troubleshooting.html:206:

  internally linking to /documentation/logging-an-app/access-logs.html#accessing-application-log-data, which does not exist


HTML-Proofer found 1 failure!
```
https://github.com/ministryofjustice/cloud-platform-user-guide/actions/runs/11518998116/job/32066998052#step:4:1991