### PR TITLE
revert depandabot change from upload-artifact@v4 to v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           /scripts/deploy.sh
       - name: Upload artifact to be published
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: github-pages
           path: artifact.tar


### PR DESCRIPTION
Revert dependabot change https://github.com/ministryofjustice/cloud-platform-user-guide/pull/1624:-
uses: actions/upload-artifact@v3
uses: actions/upload-artifact@v4

as Deploy is failing with 2 errors=
https://github.com/ministryofjustice/cloud-platform-user-guide/actions/runs/11615435824





