### PR TITLE
replace targetCPUUtilizationPercentage with the metrics array

### DIFF
--- a/source/documentation/concepts/deploying.html.md.erb
+++ b/source/documentation/concepts/deploying.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Deploying to the Cloud Platform
-last_reviewed_on: 2024-10-17
+last_reviewed_on: 2024-11-08
 review_in: 3 months
 layout: google-analytics
 ---
@@ -145,7 +145,13 @@ spec:
     name: my-app-name
   minReplicas: 1
   maxReplicas: 5
-  targetCPUUtilizationPercentage: 95
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 95
 ```
 
 The above manifest will ensure a minimum of 1 replica is available for the deployment called my-app-name, but will increase replicas up to 5 when the CPU utilization is above 95%.

--- a/source/documentation/concepts/deploying.html.md.erb
+++ b/source/documentation/concepts/deploying.html.md.erb
@@ -154,7 +154,7 @@ spec:
         averageUtilization: 95
 ```
 
-The above manifest will ensure a minimum of 1 replica is available for the deployment called my-app-name, but will increase replicas up to 5 when the CPU utilization is above 95%.
+The above manifest will ensure a minimum of 1 replica is available for the deployment called my-app-name, but will increase replicas, up to a maximum of 5, when the CPU utilization is above 95%.
 
 To configure what value to set for `targetCPUUtilizationPercentage` depends on resource limits set up in your namespace and how much the actual pods consume.
 This [limitrange file] defines the defaults we assign to new namespaces.


### PR DESCRIPTION
relates to https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics