### PR TITLE
Update link to Blank dashboard in Grafana

### DIFF
--- a/source/documentation/monitoring-an-app/prometheus.html.md.erb
+++ b/source/documentation/monitoring-an-app/prometheus.html.md.erb
@@ -77,7 +77,7 @@ and setup CI/CD to deploy it to your namespace, in a similar way to you deploy y
 
 1. Sign in to Grafana - see the [links below](#how-to-access-monitoring-tools) - with your GitHub account.
 
-2. Go to the ['Blank Dashboard'](https://grafana.live.cloud-platform.service.justice.gov.uk/d/e8e2821c-d527-475f-b116-34dd0fbc5c7e/blank-dashboard?orgId=1) (either using that link or search for a dashboard with that name). All users are able to edit dashboards but cannot save the changes.
+2. Go to the ['Blank Dashboard'](https://grafana.live.cloud-platform.service.justice.gov.uk/d/be4lvvmud43k0a/blank-dashboard) (either using that link or search for a dashboard with that name). All users are able to edit dashboards but cannot save the changes.
 
 3. Use the UI to modify the dashboard as you see fit.
 


### PR DESCRIPTION
When following the guide to create a new Grafana dashboard I noticed the Blank dashboard link was no longer working.