### PR TITLE
Update link to domain naming standard

### DIFF
--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Using a custom domain
-last_reviewed_on: 2024-10-09
+last_reviewed_on: 2024-12-06
 review_in: 6 months
 layout: google-analytics
 ---
@@ -151,7 +151,7 @@ Once you've made the changes to your `Ingress`, the cluster (and more specifical
 
 
 [env-repo]: https://github.com/ministryofjustice/cloud-platform-environments/
-[naming-domains]: https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-domains.html
+[naming-domains]: https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domain-naming-standard.html
 [creating-zone]: /documentation/other-topics/route53-zone.html#creating-a-route-53-hosted-zone
 [support-ticket]: https://github.com/ministryofjustice/cloud-platform/issues/new?template=cloud-platform-support-request.md&labels=support+team
 [wiki-domain-structure]: https://en.wikipedia.org/wiki/Domain_Name_System#Structure


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the link to the new location for the MoJ Domain Naming Standard. All DNS related guidance is being co-located in the Operations Engineering User Guide.

## ♻️ What's changed

- Updated link to Domain Naming standard