### PR TITLE
Update YAML key to be consistent with the example

### DIFF
--- a/source/documentation/concepts/deploying.html.md.erb
+++ b/source/documentation/concepts/deploying.html.md.erb
@@ -156,7 +156,7 @@ spec:
 
 The above manifest will ensure a minimum of 1 replica is available for the deployment called my-app-name, but will increase replicas, up to a maximum of 5, when the CPU utilization is above 95%.
 
-To configure what value to set for `targetCPUUtilizationPercentage` depends on resource limits set up in your namespace and how much the actual pods consume.
+To configure what value to set for `averageUtilization` depends on resource limits set up in your namespace and how much the actual pods consume.
 This [limitrange file] defines the defaults we assign to new namespaces.
 
 - Check how much defaults is set for your namespace
@@ -166,7 +166,7 @@ This [limitrange file] defines the defaults we assign to new namespaces.
 kubectl top pods -n <namespace>
 ```
 If your namespace `defaultRequest.cpu : 10m` and you pods consumes `8m` wihtout any traffic, then the usual CPUUtilizationPercentage is 80%.
-The pods doesnot need scaling until it reaches 95% of the `defaultRequest.cpu` which is already reserved for each of the containers. Hence the `targetCPUUtilizationPercentage` can be set as 95%.
+The pods doesnot need scaling until it reaches 95% of the `defaultRequest.cpu` which is already reserved for each of the containers. Hence the `averageUtilization` can be set as 95%.
 
 Run the following command to apply:
 


### PR DESCRIPTION
The example yaml on line 136 was updated recently from `targetCPUUtilizationPercentage` to a cpu target with `averageUtilization`, reflecting changes between v1 and v2.

I assume the guidance should remain the same, but I've updated the references to use the correct name.

(see previous discussion in this PR https://github.com/ministryofjustice/cloud-platform-user-guide/pull/1725)