### PR TITLE
Increase review period to 6 months

### DIFF
--- a/source/documentation/concepts/cp-tech-overview.html.md.erb
+++ b/source/documentation/concepts/cp-tech-overview.html.md.erb
@@ -66,4 +66,4 @@ As soon as you do this, the cluster will recognise that the container which is c
 [get a namespace]: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/env-create.html#creating-a-cloud-platform-environment
 [terraform]: https://www.terraform.io/
 [RDS database]: https://aws.amazon.com/rds/
-[secrets]: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/add-secrets-to-deployment.html#adding-a-secret-to-an-application
+[secrets]: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/add-secrets-to-deployment.html

--- a/source/documentation/concepts/deploying.html.md.erb
+++ b/source/documentation/concepts/deploying.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploying to the Cloud Platform
 last_reviewed_on: 2024-11-08
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/concepts/namespace-limits.html.md.erb
+++ b/source/documentation/concepts/namespace-limits.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Namespace/Container Resource Limits
 last_reviewed_on: 2024-10-28
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/deploying-an-app/add-aws-resources.html.md.erb
+++ b/source/documentation/deploying-an-app/add-aws-resources.html.md.erb
@@ -156,4 +156,4 @@ the [#ask-cloud-platform](https://mojdt.slack.com/messages/C57UPMZLY/) Slack cha
 [rds-mssql-instance]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/blob/main/examples/rds-mssql.tf
 [rds-mysql-instance]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/blob/main/examples/rds-mysql.tf
 [rds-postgresql-instance]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/blob/main/examples/rds-postgresql.tf
-[download-cli]: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#installation
+[download-cli]: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html

--- a/source/documentation/deploying-an-app/cleaning-up.html.md.erb
+++ b/source/documentation/deploying-an-app/cleaning-up.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Removing an unneeded namespace
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/deploying-an-app/cleaning-up.html.md.erb
+++ b/source/documentation/deploying-an-app/cleaning-up.html.md.erb
@@ -21,7 +21,7 @@ If you have any ECR resources in your namespace which still contain images,  Con
 will fail when trying to delete the registry. You can either delete the images manually, 
 or prepare the ECR for deletion by doing the following:
 
-- Set the [`deletion_protection = false`](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/blob/main/examples/ecr.tf#L73-L78)
+- Set the [`deletion_protection = false`](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/blob/main/examples/ecr.tf)
 argument in your ECR module code.
 - Raise a PR to apply this configuration change to your ECR resource.
 - Merge the PR, and proceed with the namespace deletion process.

--- a/source/documentation/deploying-an-app/relational-databases/create.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/create.html.md.erb
@@ -128,7 +128,7 @@ Instance types are named based on their family/purpose, generation, any addition
 
 For Amazon RDS, instance types will always be prefixed with `db`.
 
-You can read the [supported DB engines for DB instance classes](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#Concepts.DBInstanceClass.Support) for more information.
+You can read the [supported DB engines for DB instance classes](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Support.html) for more information.
 
 ### Table of instance types
 

--- a/source/documentation/deploying-an-app/relational-databases/upgrade-aurora.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/upgrade-aurora.html.md.erb
@@ -10,8 +10,8 @@ layout: google-analytics
 If you have an Aurora DB Cluster in the Cloud Platform, you must keep it up-to-date and use the most cost effective instance type for your needs.
 
 AWS publishes an end-of-life schedule for major and minor versions of 
-[Postgresql](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.VersionPolicy.html#Aurora.VersionPolicy.MajorVersions)
- and [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.html) 
+[Postgresql](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html)
+ and [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html) 
  to help you keep your database up-to-date and plan for upgrades.
 
 ## Things to note before upgrading a database version
@@ -27,7 +27,7 @@ AWS publishes an end-of-life schedule for major and minor versions of
 To upgrade your major Aurora DB Cluster version, complete these eight steps:
 
 1. Check if your current **and** new major database version supports the instance type you're currently using by reading
-[Supported DB instance classes](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.html#Concepts.DBInstanceClass.SupportAurora)
+[Supported DB instance classes](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.html)
 
 If your new major database version does not support your current instance type, update the instance type **first** before upgrading your major database version. 
 

--- a/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
@@ -91,7 +91,7 @@ To upgrade your minor database version, complete these three steps:
 
 ### Upgrade paths
 
-You should refer to the end-of-life schedule for major and minor versions for [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html), [MariaDB](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MariaDB.Concepts.VersionMgmt.html), [Microsoft SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.VersionSupport), and [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html) to understand your upgrade paths. Typically, you will be able to upgrade to the latest minor version available on RDS.
+You should refer to the end-of-life schedule for major and minor versions for [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html), [MariaDB](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MariaDB.Concepts.VersionMgmt.html), [Microsoft SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Concepts.General.VersionSupport.html), and [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html) to understand your upgrade paths. Typically, you will be able to upgrade to the latest minor version available on RDS.
 
 ## Upgrading to a new major database version
 
@@ -118,7 +118,7 @@ To upgrade your major database version, complete these eight steps:
 
 2. Understand your major version upgrade paths from your current `db_engine_version` by reading [Upgrade paths for major version upgrades](/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-to-a-new-major-database-version-upgrade-paths)
 
-3. Check if your current **and** new major database version supports the instance type you're currently using by reading [Supported DB engines for DB instance classes](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#Concepts.DBInstanceClass.Support)
+3. Check if your current **and** new major database version supports the instance type you're currently using by reading [Supported DB engines for DB instance classes](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Support.html)
 
     If not, follow the [Changing your database instance type](/documentation/deploying-an-app/relational-databases/upgrade.html#changing-your-database-instance-type) guide first to change your instance class to one that is supported by your current and new major database version. You **must** change your instance type **before** attempting to upgrade, otherwise it will fail.
 
@@ -170,7 +170,7 @@ To upgrade your major database version, complete these eight steps:
 
 ### Upgrade paths
 
-You should refer to the major version upgrade paths for [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion), [MariaDB](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.MariaDB.html#USER_UpgradeDBInstance.MariaDB.Major), [Microsoft SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.VersionSupport), and [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.MySQL.html#USER_UpgradeDBInstance.MySQL.Major) to understand your upgrade paths from your current database engine version.
+You should refer to the major version upgrade paths for [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html), [MariaDB](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.MariaDB.html), [Microsoft SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Concepts.General.VersionSupport.html), and [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.MySQL.html) to understand your upgrade paths from your current database engine version.
 
 ## Changing your database instance type
 

--- a/source/documentation/deploying-an-app/running-rails-migrations.html.md.erb
+++ b/source/documentation/deploying-an-app/running-rails-migrations.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: How do I run Rails database migrations?
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/monitoring-an-app/application-metrics.html.md.erb
+++ b/source/documentation/monitoring-an-app/application-metrics.html.md.erb
@@ -16,7 +16,7 @@ The example application in this document will be the [Ruby reference app](https:
 The application latency [metric](https://prometheus.io/docs/concepts/metric_types/) is quite basic, but our intention is to get you started.
 
 ### Assumptions
-To keep this document short, we will assume you already have an application up and running in a namespace on the Cloud Platform, if not, please see [Deploying a multi-container application to the Cloud Platform](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/deploying-an-example-application.html#deploying-a-multi-container-application-to-the-cloud-platform).
+To keep this document short, we will assume you already have an application up and running in a namespace on the Cloud Platform, if not, please see [Deploying an example application to the Cloud Platform](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/deploying-an-example-application.html).
 
 >Note: make sure your container has the correct timezone [see see here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/requirements.html#setting-utc-timezone-inside-your-container)
 
@@ -56,7 +56,7 @@ curl https://myapp.cloud-platform/metrics
 
 ### Add Service endpoint and ServiceMonitor
 
-We need to expose the metrics endpoint with a `Service` and tell the Cloud Platform Prometheus to scrape the endpoint with a `ServiceMonitor` object in Kubernetes. A `ServiceMonitor` is a custom resource definition ([CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions/)) that allows you to automatically generate Prometheus scrape configuration based on a specified resource.
+We need to expose the metrics endpoint with a `Service` and tell the Cloud Platform Prometheus to scrape the endpoint with a `ServiceMonitor` object in Kubernetes. A `ServiceMonitor` is a custom resource definition ([CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)) that allows you to automatically generate Prometheus scrape configuration based on a specified resource.
 
 In this example, we're using the same port to expose both our application and metrics endpoint, so we'll need to query our existing `Service` for the current port name. However, if you're exposing a different port, you'll need to either amend your current `Service` or create a new one.
 

--- a/source/documentation/monitoring-an-app/how-to-create-alarms.html.md.erb
+++ b/source/documentation/monitoring-an-app/how-to-create-alarms.html.md.erb
@@ -24,7 +24,7 @@ This guide assumes the following:
 
    * Follow the steps in "Set up incoming webhooks" (starting with "Create an app"  "From scratch")
 
-2. Create a [kubernetes secret](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/add-secrets-to-deployment.html#adding-a-secret-to-an-application) to store the slack webhook.
+2. Create a [kubernetes secret](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/add-secrets-to-deployment.html#configuring-secrets-manually-using-kubenetes-secret) to store the slack webhook.
 
 3. Create a [ticket to request a new alert route in Alertmanager](https://github.com/ministryofjustice/cloud-platform/issues/new?assignees=&labels=&template=cloud-platform-support-request.md). The Cloud Platform team will need the following information:
 
@@ -163,7 +163,7 @@ this will alert on the rate of 403 errors on the ingress host name connect to th
 
 In the event of a serious failure, or for a required upgrade, it may be necessary to re-install Prometheus.
 
-`PrometheusRule` is a [CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/##customresourcedefinitions) that declaratively defines a desired Prometheus rule.
+`PrometheusRule` is a [CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) that declaratively defines a desired Prometheus rule.
 
 If for any reason Prometheus has to be re-installed, **all PrometheusRules are removed with the CRD.**
 
@@ -181,7 +181,6 @@ If you think this may be causing an issue with your application, we recommend ra
 
 ### Further reading
 
-- [Prometheus Operator - Getting Started](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md)
-- [Alerting](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)
+- [Prometheus](https://github.com/prometheus-operator/prometheus-operator/)
 
 [env-create]: /documentation/getting-started/env-create.html#creating-a-cloud-platform-environment

--- a/source/documentation/monitoring-an-app/how-to-use-cloudwatch-datasource.html.md.erb
+++ b/source/documentation/monitoring-an-app/how-to-use-cloudwatch-datasource.html.md.erb
@@ -50,5 +50,5 @@ Follow the guidance [here][dynamic-queries], to do dynamic queries using dimensi
 [default-dashboards]: https://grafana.com/grafana/dashboards?dataSource=CloudWatch
 [env-repo]: https://github.com/ministryofjustice/cloud-platform-environments
 [cp-dashboards]: https://grafana.cloud-platform.service.justice.gov.uk/dashboards
-[dynamic-queries]: https://grafana.com/docs/grafana/latest/datasources/cloudwatch/#dynamic-queries-using-dimension-wildcards
+[dynamic-queries]: https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/query-editor/#create-dynamic-queries-with-dimension-wildcards
 [cloudwatch-metrics]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html

--- a/source/documentation/monitoring-an-app/prometheus.html.md.erb
+++ b/source/documentation/monitoring-an-app/prometheus.html.md.erb
@@ -192,8 +192,6 @@ Grafana: [https://grafana.cloud-platform.service.justice.gov.uk](https://grafana
 ### Other monitoring tools
 
 [Sentry](https://sentry.io/welcome/) isn't supported by the Cloud Platform team, but it is a useful tool for monitoring errors in your application.
-If you'd like to read more, head over to the
-[operations-engineering](https://operations-engineering.service.justice.gov.uk/documentation/services/sentry.html#sentry-io) page.
 
 ### Validate Prometheus Rule
 
@@ -209,7 +207,7 @@ If you'd like to read more, head over to the
 
 [Grafana]
 
-[Prometheus Overview and Architecture](https://prometheus.io/docs/introduction/overview/###architecture)
+[Prometheus Overview and Architecture](https://prometheus.io/docs/introduction/overview/#architecture)
 
 [Thanos]
 

--- a/source/documentation/networking/ip-filtering.html.md.erb
+++ b/source/documentation/networking/ip-filtering.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Cloud Platform IP Addresses
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/networking/modsecurity.html.md.erb
+++ b/source/documentation/networking/modsecurity.html.md.erb
@@ -170,7 +170,7 @@ The Paranoia Level (PL) setting allows you to choose the desired level of rule c
 Traditional Detection or Passive Mode is the most basic operating mode where all of the rules are run as individual entities. In this mode, no intelligence is shared between rules and each rule has no information about any previous rule matches. That is to say, in this mode, if a rule triggers, it will execute any disruptive/logging actions specified on the current rule.
 
 Anomaly scoring mode implements the concept of Collaborative Detection and Delayed Blocking. Rule logic has been set to decouple the inspection/detection from the blocking functionality. The individual rules can be run so that the detection remains, however instead of applying any disruptive action at that point, the rules will contribute to a transactional anomaly score collection. In addition, each rule will also store meta-data about each rule match (such as the Rule ID, Attack Category, Matched Location and Matched Data) for later logging.
-For more information in anomaly scoring, click [here](https://www.modsecurity.org/CRS/Documentation/anomaly.html#anomaly-scoring-mode)
+For more information in anomaly scoring, click [here](https://coreruleset.org/docs/2-how-crs-works/2-1-anomaly_scoring/)
 
 #### Sensitive logs
 

--- a/source/documentation/networking/network-policy.html.md.erb
+++ b/source/documentation/networking/network-policy.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Network Policies
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/other-topics/domain-name-character-length.html.md.erb
+++ b/source/documentation/other-topics/domain-name-character-length.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: DNS Domain Name length considerations
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/other-topics/git-crypt-setup.html.md.erb
+++ b/source/documentation/other-topics/git-crypt-setup.html.md.erb
@@ -20,7 +20,7 @@ We use `git-crypt` to ensure that application secrets are encrypted at rest in g
 
 ### Setup
 
-- If the repository has not been setup before, please follow the [git-crypt documentation](https://github.com/AGWA/git-crypt##using-git-crypt) to do so.
+- If the repository has not been setup before, please follow the [git-crypt documentation](https://github.com/AGWA/git-crypt#using-git-crypt) to do so.
 
 otherwise,
 

--- a/source/documentation/other-topics/k8s-jobs.html.md.erb
+++ b/source/documentation/other-topics/k8s-jobs.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes jobs
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/other-topics/persistent-volume-encryption-snapshot.html.md.erb
+++ b/source/documentation/other-topics/persistent-volume-encryption-snapshot.html.md.erb
@@ -106,7 +106,7 @@ resource "kubernetes_secret" "persistentvolume_backup_sec" {
 
 If you want to [restore a PV from a snapshot][restore-snapshot], speak to the cloud-platform team in the #ask-cloud-platform channel.
 
-[gp3]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/storage.tf#L52-L68
+[gp3]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/storage.tf
 [env-repo]: https://github.com/ministryofjustice/cloud-platform-environments/
 [storage class]: https://kubernetes.io/docs/concepts/storage/storage-classes/
 [dynamic-provisioning]: https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/

--- a/source/documentation/other-topics/persistent-volume-encryption-snapshot.html.md.erb
+++ b/source/documentation/other-topics/persistent-volume-encryption-snapshot.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volume encryption at rest and daily snapshots
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/other-topics/rds-external-access.html.md.erb
+++ b/source/documentation/other-topics/rds-external-access.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Accessing your RDS database
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/other-topics/rds-metrics-prometheus.html.md.erb
+++ b/source/documentation/other-topics/rds-metrics-prometheus.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Viewing RDS Database Metrics
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/other-topics/rds-snapshots.html.md.erb
+++ b/source/documentation/other-topics/rds-snapshots.html.md.erb
@@ -9,7 +9,7 @@ layout: google-analytics
 
 RDS snapshots have multiple purposes: migrations, backups, etc. When RDS DB instances are created using the [Cloud Platform RDS terraform module](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance), an IAM user account is created for management purposes. This user can create, delete, copy, and restore RDS snapshots.
 
-Examples of managing RDS DB snapshots using the AWS CLI can be found in the [README](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance#4-managing-rds-snapshots---backups-and-restores) within the [RDS terraform module](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance)
+Examples of managing RDS DB snapshots using the AWS CLI can be found in the [README](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance?tab=readme-ov-file#managing-rds-snapshots---backups-and-restores) within the [RDS terraform module](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance)
 
 ## Considerations
 

--- a/source/documentation/other-topics/rds-ssl.html.md.erb
+++ b/source/documentation/other-topics/rds-ssl.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: SSL connections with RDS
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/other-topics/rds-ssl.html.md.erb
+++ b/source/documentation/other-topics/rds-ssl.html.md.erb
@@ -91,7 +91,7 @@ psql: FATAL:  no pg_hba.conf entry for host "172.20.32.241", user "fDsQgBlavX", 
 The parameter `force_ssl` can be overriden by changing the `db_parameter` when calling the module.
 
 [aws-sec-wp]: https://d1.awsstatic.com/whitepapers/aws-security-whitepaper.pdf
-[aws-rds-ssl]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL
+[aws-rds-ssl]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Concepts.General.SSL.html
 [libpq-ssl]: https://www.postgresql.org/docs/current/libpq-ssl.html
 [mitm]: https://en.wikipedia.org/wiki/Man-in-the-middle_attack
 [rds-module]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/#inputs

--- a/source/documentation/other-topics/rotate-tokens-keys.html.md.erb
+++ b/source/documentation/other-topics/rotate-tokens-keys.html.md.erb
@@ -22,7 +22,7 @@ Ensure you are on the latest version of the [cloud-platform-terraform-serviceacc
 
 Update your Terraform code to include the `serviceaccount_token_rotated_date` variable and set it to the current date in the format `dd-mm-yyyy`, and raise a PR for this update. See the mode [example code](https://github.com/ministryofjustice/cloud-platform-terraform-serviceaccount/blob/main/examples/serviceaccount.tf#L8) for more details.
 
-Once applied Terraform will destroy and recreate your Service Account token. if you are pushing this token to GitHub no further action is required; if you are using this token statically in external services like CircleCI then you will need to update the relevant fields manually. See [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/kubernetes-service-accounts.html#obtain-the-new-service-account-credentials) for more details.
+Once applied Terraform will destroy and recreate your Service Account token. if you are pushing this token to GitHub no further action is required; if you are using this token statically in external services like CircleCI then you will need to update the relevant fields manually. See [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rotate-tokens-keys.html#serviceaccount-tokens) for more details.
 
 ### AWS credentials
 
@@ -110,7 +110,7 @@ In cases where you have a need for creating and storing AWS Access keys as Kuber
     ```
 
     > **Note:** Make sure you are using the latest version of the [Elasticache module][elasticache-module-version]. You may also wish to check
-    whether your `kubernetes_secret` is already set to contain `access_key_id` and `secret_access_key` data, as shown in the example code [here](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/blob/main/examples/elasticache.tf#L47-L48).
+    whether your `kubernetes_secret` is already set to contain `access_key_id` and `secret_access_key` data, as shown in the example code [here](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/blob/main/examples/elasticache.tf).
 
     This follow the **ROTATE** strategy and when applying this adds an additional AUTH token to the server and remove the the oldest AUTH token from the server.
     Hence the previous token will be retained allowing a server to support up to two most recent AUTH tokens at a given time. This also updates the `auth_token` stored as a Kubernetes secret in your namespace.

--- a/source/documentation/other-topics/security-testing-and-ithc.html.md.erb
+++ b/source/documentation/other-topics/security-testing-and-ithc.html.md.erb
@@ -27,7 +27,7 @@ To help ITHC testers get familiar with using Cloud Platform you may wish to send
 
 ## Notifiable testing
 
-AWS require you to contact them if you do security testing on AWS services outside a small [Permitted Services](https://aws.amazon.com/security/penetration-testing/#Permitted_Services) list. This list covers Cloud Platform's Kubernetes cluster nodes (but not the EKS API endpoint) and RDS, for example. But other services like ElastiCache or ECR **do** require notifying AWS, if they are involved in your security test. In this case, please get in touch with the Cloud Platform team to coordinate with contacting AWS.
+AWS require you to contact them if you do security testing on AWS services outside a small [Permitted Services](https://aws.amazon.com/security/penetration-testing/) list. This list covers Cloud Platform's Kubernetes cluster nodes (but not the EKS API endpoint) and RDS, for example. But other services like ElastiCache or ECR **do** require notifying AWS, if they are involved in your security test. In this case, please get in touch with the Cloud Platform team to coordinate with contacting AWS.
 
 ## Load / stress testing
 

--- a/source/documentation/other-topics/zero-downtime-deployment.html.md.erb
+++ b/source/documentation/other-topics/zero-downtime-deployment.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Zero Downtime Deployments
 last_reviewed_on: 2025-01-27
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 

--- a/source/documentation/reference/namespace-definition-files.html.md.erb
+++ b/source/documentation/reference/namespace-definition-files.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes: namespace definition files"
 last_reviewed_on: 2024-10-28
-review_in: 3 months
+review_in: 6 months
 layout: google-analytics
 ---
 


### PR DESCRIPTION
After discussing in retro we agreed to increase the review period for documentation to 6 months.  Our infrastructure doesn't change that rapidly and when it does we update documents, this check is an additional one to make sure things don't get out of date.  By increasing the review time period we decrease the burden of reviewing docs.

Also fixing a load of broken links, these are all the genuine broken links I can see, takes the total down from 67 to 39, the rest appear to be links requiring authentication or GitHub line marking which it doesn't seem to like.