### PR TITLE
docs: Update Canary deployment user guide

### DIFF
--- a/source/documentation/deploying-an-app/ingress-with-duplicate-hostnames.html.md.erb
+++ b/source/documentation/deploying-an-app/ingress-with-duplicate-hostnames.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Allow Ingress with duplicate hostname across namespaces
-last_reviewed_on: 2025-02-25
+last_reviewed_on: 2025-03-04
 review_in: 6 months
 layout: google-analytics
 ---
@@ -46,6 +46,7 @@ There are two weight annotations available:
 
 - NGINX Ingress Level:
     - `nginx.ingress.kubernetes.io/canary-weight` controls the percentage of traffic routed to the canary Ingress at the Ingress level.
+    - You only need to add this to the Canary Ingress (New Deployment in the `prod-new` Namespace in the below example)
     - You may find more [info here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary).
 
 - Route 53 Level:
@@ -54,9 +55,9 @@ There are two weight annotations available:
 
 Although both annotations are available, it is often simpler to use a single weighting mechanism as your baseline for traffic splitting. Consolidating to one value reduces configuration complexity and potential confusion. You may choose to adjust one of the weight base on your requirement.
 
-For example, you might initially set both `nginx.ingress.kubernetes.io/canary-weight` to 50 for a 50/50 split, and then later adjust one weight to 100 and the other to 0 to achieve a full switch.
+For example, you might initially set the Canary Ingress `nginx.ingress.kubernetes.io/canary-weight` to `50` for a 50/50 split, and then later adjust the weight to `100` to achieve a full switch.
 
-If you would like to fully cut over to the new version and implement a "blue green" deployment strategy, a full traffic switch on using one of the weighting annotations (i.e. `100/0` or `0/100`) can be achieved by setting the weight to `100` and the other to `0`.
+If you would like to fully cut over to the new version and implement a "blue green" deployment strategy, a full traffic switch can be done by setting the Canary Ingress `nginx.ingress.kubernetes.io/canary-weight` to `100`.
 
 
 ## Canary Deployment Example
@@ -80,7 +81,7 @@ Using the canary annotations instructs the NGINX Ingress Controller allow you to
 Below are sample YAML files for a Canary deployment scenario where duplicate hostnames across namespaces are allowed because the required annotations are present and identical.
 
 #### Stable Ingress (Existing Deployment in the “prod-old” Namespace)
-This Ingress represents your existing deployment in the `prod-old` namespace. It is configured with the required override and canary annotations.
+This Ingress represents your existing deployment in the `prod-old` namespace. It is configured with the required override and does not need canary annotations.
 
 ```
 apiVersion: networking.k8s.io/v1
@@ -89,12 +90,10 @@ metadata:
   name: helloworld-prod-old
   namespace: prod-old
   annotations:
-    nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "50"
     allow-duplicate-host: "true"
-    allowed-duplicate-ns: "prod-old,prod-new"   # Must be identical on both ingresses.
+    allowed-duplicate-ns: "prod-old,prod-new"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    external-dns.alpha.kubernetes.io/set-identifier: helloworld-prod-old
+    external-dns.alpha.kubernetes.io/set-identifier: helloworld-prod-old-prod-old-green
 spec:
   rules:
   - host: helloworld.apps.live.cloud-platform.service.justice.gov.uk
@@ -110,7 +109,7 @@ spec:
 ```
 
 #### Canary Ingress (New Deployment in the `prod-new` Namespace)
-This Ingress represents your new `prod-new` deployment. It uses the same hostname and same path as the stable Ingress, and its annotations must match exactly.
+This Ingress represents your new `prod-new` deployment. It uses the same hostname and same path as the stable Ingress, and its annotations must match exactly. It includes the canary annotations so you can adjust traffic distribution.
 
 ```
 apiVersion: networking.k8s.io/v1
@@ -124,7 +123,7 @@ metadata:
     allow-duplicate-host: "true"
     allowed-duplicate-ns: "prod-old,prod-new"   # Must be identical on both ingresses.
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    external-dns.alpha.kubernetes.io/set-identifier: helloworld-prod-new
+    external-dns.alpha.kubernetes.io/set-identifier: helloworld-prod-new-prod-new-green
 spec:
   rules:
   - host: helloworld.apps.live.cloud-platform.service.justice.gov.uk
@@ -147,6 +146,79 @@ spec:
   - Apply the YAML for the new Ingress in the `prod-new` namespace. The deployment is allowed only if both Ingresses include all required annotations and the allowed-duplicate-ns values match exactly.
 
 3. Traffic Management:
-  - Use the `nginx.ingress.kubernetes.io/canary-weight` annotation to adjust traffic distribution in nginx level between your prod-old and prod-new deployments. For example, you might start with a `50/50` split and later adjust one weight to 100 and the other to 0 to fully shift traffic.
+  - Use the `nginx.ingress.kubernetes.io/canary-weight` annotation to adjust traffic distribution in nginx level between your prod-old and prod-new deployments. 
+  - If you set `nginx.ingress.kubernetes.io/canary-weight` to **0** on the Canary Ingress, then 0% of traffic will be routed to the new version, and all traffic will go to the stable deployment.
+  - Conversely, if you set the canary weight to **100**, then 100% of the traffic will be routed to the new version.
+  - You can test these scenarios by updating the annotation on the Canary Ingress accordingly.
+
+### Canary Deployment with sticky session
+
+To ensure that once a user is routed to one version they continue to see that same version, you can enable cookie-based session affinity (sticky sessions) on your Ingress.
+
+You may find more info about session affinity [here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#session-affinity).
+
+Below are sample YAML examples that demonstrate a stable (prod-old) deployment and a canary (prod-new) deployment with sticky sessions enabled.
+
+#### Stable Ingress (Existing Deployment in the “prod-old” Namespace)
+This Ingress represents your existing deployment in the `prod-old` namespace for sticky session.
+
+```
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: helloworld-prod-old
+  namespace: prod-old
+  annotations:
+    allow-duplicate-host: "true"
+    allowed-duplicate-ns: "prod-old,prod-new"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: helloworld-prod-old
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+spec:
+  rules:
+  - host: helloworld.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: helloworld-prod-old
+            port:
+              number: 80
+```
+
+#### Canary Ingress (New Deployment in the `prod-new` Namespace)
+This Ingress represents your new `prod-new` deployment in the `prod-new` namespace for sticky session.
+
+```
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: helloworld-prod-new
+  namespace: prod-new
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
+    allow-duplicate-host: "true"
+    allowed-duplicate-ns: "prod-old,prod-new"   # Must be identical on both ingresses.
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: helloworld-prod-new
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+spec:
+  rules:
+  - host: helloworld.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/" 
+        backend:
+          service:
+            name: helloworld-prod-new
+            port:
+              number: 80
+```
+
+If you would like to customize cookie session, you may find more info [here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#cookie-affinity).
 
 For further assistance or questions, please contact us in #ask-cloud-platform.


### PR DESCRIPTION
- Tested and verified the yaml files
- Update Canary deployment user guide
- We only need to set Canary annotation for the "new deployment"
- When we set the canary annotation for the "old deployment", it will get "service unavailable"

![image](https://github.com/user-attachments/assets/3d8389dd-b474-4fb6-b3d1-b2179028d695)

- Update the guide for the correct setting

- Update the guide for Canary deployment with sticky session