### PR TITLE
Update DB upgrade page

### DIFF
--- a/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
@@ -139,9 +139,11 @@ To upgrade your major database version, complete these eight steps:
     }
     ```
 
->Note: It is essential that you set `prepare_for_major_upgrade` to `true`. This will temporarily set your database's parameter group to the RDS default, and prevent a failed apply during upgrade caused by clashing parameter group resources.
-    
+    > **Note:** It is essential that you set `prepare_for_major_upgrade` to `true`. This will temporarily set your database's parameter group to the RDS default, and prevent a failed apply during upgrade caused by clashing parameter group resources.
+
+    ```shell
     As soon as this PR is merged, the major version upgrade will begin.
+    ```
 
 6. Once the major version upgrade has finished, raise and merge a PR that turns off the `prepare_for_major_upgrade` attribute that was turned on in step 5:
 


### PR DESCRIPTION
The indentation of notes and warnings reset the numbering and made it hard to follow the numbered steps

It also updates the Note: prefix to be bold, matching other uses on the same page

Replaces the live version
![image](https://github.com/user-attachments/assets/984f57f7-3117-4b19-bba8-17084eb8a80d)

with
![image](https://github.com/user-attachments/assets/fbba6b98-d857-4f0e-b081-74d6782cc758)
