### PR TITLE
Updating cluster references to 1.30 after upgrade.

### DIFF
--- a/source/documentation/getting-started/kubectl-config.html.md.erb
+++ b/source/documentation/getting-started/kubectl-config.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Connecting to the Cloud Platform's Kubernetes cluster
-last_reviewed_on: 2024-12-27
+last_reviewed_on: 2025-05-01
 review_in: 6 months
 layout: google-analytics
 ---
@@ -17,7 +17,7 @@ Once installed and configured, you can use `kubectl` to deploy and manage your a
 
 >You should install a version of `kubectl` that is within one minor version of the Cloud Platform's Kubernetes cluster.
 
-The Cloud Platform's current [Kubernetes cluster version is 1.29](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf#L37-L42). You must use a kubectl version that is within one minor version difference of the cluster. Therefore, you should install `kubectl` version 1.28, 1.29 or 1.30.
+The Cloud Platform's current [Kubernetes cluster version is 1.30](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf#L37-L42). You must use a kubectl version that is within one minor version difference of the cluster. Therefore, you should install `kubectl` version 1.29, 1.30 or 1.31.
 
 There is official documentation on how to install `kubectl`, including how to install a specific version:
 

--- a/source/documentation/other-topics/apiversion-changes-cronjob-k8s-1-25.html.md.erb
+++ b/source/documentation/other-topics/apiversion-changes-cronjob-k8s-1-25.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Updating CronJob API version for Cloud Platform - removed Kubernetes v1.25
-last_reviewed_on: 2025-04-17
+last_reviewed_on: 2025-05-01
 review_in: 6 months
 layout: google-analytics
 ---
@@ -9,7 +9,7 @@ layout: google-analytics
 
 The `batch/v1beta1` API version of CronJob is deprecated as of Kubernetes release v1.21, and will no longer served as of v1.25.
 
-Cloud Platform users must ensure any CronJob manifests are migrated to use the `batch/v1` API version, which is supported on our current cluster version (v1.29 as of writing).
+Cloud Platform users must ensure any CronJob manifests are migrated to use the `batch/v1` API version, which is supported on our current cluster version (v1.30 as of writing).
 
 Further details can be found within the [Kubernetes deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125)
 

--- a/source/documentation/other-topics/apiversion-changes-hpa-k8s-1-25.html.md.erb
+++ b/source/documentation/other-topics/apiversion-changes-hpa-k8s-1-25.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Updating HorizontalPodAutoscaler API version for Cloud Platform - removed Kubernetes v1.25
-last_reviewed_on: 2025-04-17
+last_reviewed_on: 2025-05-01
 review_in: 6 months
 layout: google-analytics
 ---
@@ -11,7 +11,7 @@ The `autoscaling/v2beta1` API version of HorizontalPodAutoscaler is no longer se
 
 The `autoscaling/v2beta2` API version of HorizontalPodAutoscaler is no longer served as of v1.26.
 
-Cloud Platform users must ensure any HorizontalPodAutoscaler manifests are migrated to use the `autoscaling/v2` API version, which is supported on our current cluster version (v1.29 as of writing).
+Cloud Platform users must ensure any HorizontalPodAutoscaler manifests are migrated to use the `autoscaling/v2` API version, which is supported on our current cluster version (v1.30 as of writing).
 
 Further details can be found within the [Kubernetes deprecation guide - 1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125) and
 [Kubernetes deprecation guide - 1.26](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126)

--- a/source/documentation/other-topics/apiversion-changes-pdb-k8s-1-25.html.md.erb
+++ b/source/documentation/other-topics/apiversion-changes-pdb-k8s-1-25.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Updating PodDisruptionBudget API version for Cloud Platform - removed Kubernetes v1.25
-last_reviewed_on: 2025-04-17
+last_reviewed_on: 2025-05-01
 review_in: 6 months
 layout: google-analytics
 ---
@@ -9,7 +9,7 @@ layout: google-analytics
 
 The `policy/v1beta1` API version of PodDisruptionBudget (PDB) is deprecated as of Kubernetes release v1.21, and will no longer be served as of v1.25.
 
-Cloud Platform users must ensure any PodDisruptionBudget manifests are migrated to use the `policy/v1` API version, which is supported on our current cluster version (v1.29 as of writing).
+Cloud Platform users must ensure any PodDisruptionBudget manifests are migrated to use the `policy/v1` API version, which is supported on our current cluster version (v1.30 as of writing).
 
 Further details can be found within the [Kubernetes deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125)
 


### PR DESCRIPTION
Updating references to the cluster from 1.29 to 1.30 after upgrade.
Related issue: [#6722](https://github.com/ministryofjustice/cloud-platform/issues/6722)