### PR TITLE
text for major upgrade changed to include downtime for primary and replica

### DIFF
--- a/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
+++ b/source/documentation/deploying-an-app/relational-databases/upgrade.html.md.erb
@@ -95,7 +95,7 @@ You should refer to the end-of-life schedule for major and minor versions for [P
 
 ## Upgrading to a new major database version
 
->Note: This will cause downtime. See [Things to note before upgrading your database](#things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type).
+>Note: This will cause downtime for both the Primary and any Read Replica instance. See [Things to note before upgrading your database](#things-to-note-before-upgrading-a-database-version-or-changing-the-instance-type).
 >
 >Note: If you need to upgrade major versions more than once, e.g. from Postgres 12 to 14, and then 14 to 16, you **must** turn off `prepare_for_major_upgrade` (step 6) after each upgrade and then turn it back on (step 5). Otherwise, any upgrade after the first will fail.
 


### PR DESCRIPTION
minor text change in document Upgrading a database version or changing the instance type