### PR TITLE
fix: add flecible link checker to prevent false failures

### DIFF
--- a/.github/workflows/flex-check-links.yml
+++ b/.github/workflows/flex-check-links.yml
@@ -1,0 +1,26 @@
+# Ignores known non-critical statuses: 200, 400, 401, 402, 403, and 429.
+# Still checks external links to catch genuine 404s, but may need manual review. 
+# External links causing false-positives by throwing 404s will be allow-listed soon.
+name: Check links (Flexible)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'source/**'
+
+jobs:
+  check-links-flexible:
+    runs-on: ubuntu-latest
+    container:
+      image: ministryofjustice/tech-docs-github-pages-publisher:v3
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install dependencies
+        run: bundle install
+      - name: Build site
+        run: bundle exec middleman build --build-dir docs --relative-links
+      - name: Run HTMLProofer (Flexible)
+        run: |
+          htmlproofer ./docs --http-status-ignore "400,401,402,403,429" --allow-missing-href true


### PR DESCRIPTION
## Purpose
Provide a more flexible link-checking workflow that reduces false CI failures caused by external rate-limiting (GitHub), bot protection (StackOverflow), or authentication requirements(google docs and internal metrics/logging platforms).

## What this does?

- Adds a parallel flex-check-links.yml workflow.
- Configures HTMLProofer to ignore HTTP 400, 401, 402, 403, and 429 status codes.
- Retains external link checking to detect genuine 404s for manual review (will be allow-listed later)
- Keeps the original check-links.yml running for comparison.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7156