### PR TITLE
Fix: remove bundle and use preinstalled gems

### DIFF
--- a/.github/workflows/flex-check-links.yml
+++ b/.github/workflows/flex-check-links.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
-      - name: Install dependencies
-        run: bundle install
+      # Skip bundle install since we'll use the container's pre-installed gems
         
       - name: Build site with Middleman
         run: |
-          bundle exec middleman build --build-dir docs --relative-links --verbose
+          # Use the container's pre-installed middleman directly
+          middleman build --build-dir docs --relative-links --verbose
       
       - name: Run HTMLProofer link checks
         run: |


### PR DESCRIPTION
## Purpose
Fixes the documentation link checker workflow by optimizing how we use the tech-docs-github-pages-publisher container.
If this doesn't work, I'll consider testing Lychee as well as the workflow here https://github.com/ministryofjustice/template-documentation-site/blame/main/.github/workflows/test.yml

## What this does?

- Removes the bundle install step which was causing dependency conflicts
- Uses the pre-installed gems directly from the container
- Ensures the workflow continues even when non-critical link issues are found

Test pr error https://github.com/ministryofjustice/cloud-platform-user-guide/actions/runs/15048021243/job/42295444979?pr=1814