### PR TITLE
fix: add bundle exec to pair with middleman

### DIFF
--- a/.github/workflows/flex-check-links.yml
+++ b/.github/workflows/flex-check-links.yml
@@ -35,8 +35,8 @@ jobs:
         
       - name: Build site with Middleman
         run: |
-          # Use the container's pre-installed middleman directly
-          middleman build --build-dir docs --relative-links --verbose
+          # Use bundle exec but without reinstalling gems
+          bundle exec middleman build --build-dir docs --relative-links --verbose
       
       - name: Run HTMLProofer link checks
         run: |


### PR DESCRIPTION
Other errors have been fixed. This change is intended to point middleman towards the directory's workflow using the pre-installed bundle package in the container.
Fixes https://github.com/ministryofjustice/cloud-platform-user-guide/actions/runs/15048582056/job/42297378470?pr=1814