### PR TITLE
fix: fix causes of link checker errors

### DIFF
--- a/source/documentation/getting-started/prototype-kit.html.md.erb
+++ b/source/documentation/getting-started/prototype-kit.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Publish prototypes on the web
-last_reviewed_on: 2025-02-05
+last_reviewed_on: 2025-05-20
 review_in: 6 months
 layout: google-analytics
 ---
@@ -68,7 +68,7 @@ For example, if you choose `my-prototype` as the name, the CLI will create:
 * configure your prototype github repository to create a hostname:
 
 ```
- https://my-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/
+ https://my-prototype-main.example.apps.live.cloud-platform.service.justice.gov.uk/
 ```
 
 ## 3. Raise a PR

--- a/source/documentation/monitoring-an-app/application-metrics.html.md.erb
+++ b/source/documentation/monitoring-an-app/application-metrics.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Getting application metrics into Prometheus
-last_reviewed_on: 2025-04-17
+last_reviewed_on: 2025-05-20
 review_in: 6 months
 layout: google-analytics
 ---
@@ -51,7 +51,7 @@ curl localhost:3000/metrics
 Build, tag and push your application changes to your code repository and deploy the latest version into your Cloud Platform namespace. Confirm your `/metrics` endpoint is now accessible from your url.
 
 ```
-curl https://myapp.cloud-platform/metrics
+curl https://myapp.example.cloud-platform/metrics
 ```
 
 ### Add Service endpoint and ServiceMonitor

--- a/source/documentation/other-topics/custom-domain-cert.html.md.erb
+++ b/source/documentation/other-topics/custom-domain-cert.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Using a custom domain
-last_reviewed_on: 2024-12-06
+last_reviewed_on: 2025-05-20
 review_in: 6 months
 layout: google-analytics
 ---
@@ -33,9 +33,9 @@ To simplify management, we recommend that you only define a single zone as part 
 
 Once the zone is created, you will need to setup the necessary name server (NS) records in the parent DNS zone before you can use it. **This step must be completed before proceeding to [create a certificate](#obtaining-a-certificate)**. For more information on how this delegation method works, you can read about authoritative name servers in this [page][wiki-nameservers].
 
-If your zone is for a subdomain of `service.justice.gov.uk` (eg.: `https://myapp.service.justice.gov.uk`), you can delegate the zone by providing the nameservers to the Operations Engineering team either by contacting `#ask-operations-engineering` or by emailing [domains@digital.justice.gov.uk](mailto:domains@digital.justice.gov.uk)
+If your zone is for a subdomain of `service.justice.gov.uk` (eg.: `https://myapp.example.service.justice.gov.uk`), you can delegate the zone by providing the nameservers to the Operations Engineering team either by contacting `#ask-operations-engineering` or by emailing [domains@digital.justice.gov.uk](mailto:domains@digital.justice.gov.uk)
 
-For any other domains (including any subdomain of `gov.uk`, eg.: `https://myservice.gov.uk`), you will need to contact the parent zone's administrators (usually GDS) to set this up. If in doubt, contact `#ask-operations-engineering` who is the Domain Registrar for Ministry of Justice.
+For any other domains (including any subdomain of `gov.uk`, eg.: `https://myservice.example.gov.uk`), you will need to contact the parent zone's administrators (usually GDS) to set this up. If in doubt, contact `#ask-operations-engineering` who is the Domain Registrar for Ministry of Justice.
 
 Please note, once you setup the NS records, you'll be delegating control of the zone to the Cloud Platform. Hostnames used by your services (using `Ingresses`) will be automatically managed by the cluster.
 

--- a/source/documentation/other-topics/migrating-from-live-1-domain-name.html.md.erb
+++ b/source/documentation/other-topics/migrating-from-live-1-domain-name.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Migrating your application URL from live-1 to non-cluster specific domain
-last_reviewed_on: 2024-11-25
+last_reviewed_on: 2025-05-20
 review_in: 6 months
 layout: google-analytics
 ---
@@ -15,7 +15,7 @@ We are asking all users of the platform to check/update their Kubernetes deploym
 
 ### Do I need to update my application domain?
 
-To check whether you have a Cloud Platform hosted application still configured to use the `live-1` domain, please consult [this page](https://reports.cloud-platform.service.justice.gov.uk/live_1_domains).
+To check whether you have a Cloud Platform hosted application still configured to use the `live-1` domain, please consult [this page](https://reports.cloud-platform.service.justice.gov.uk/live_one_domains).
 
 ### Steps to follow
 


### PR DESCRIPTION
## What this does?

It ensures links that couldn't be found are replaced with their new and available paths (genuine 404s)

## Note
Prior to these fixes, Lychee flagged 12 errors.