### PR TITLE
Updated Bitnami References to Legacy

### DIFF
--- a/source/documentation/other-topics/Cronjobs.html.md.erb
+++ b/source/documentation/other-topics/Cronjobs.html.md.erb
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
           - name: hello
-            image: bitnami/nginx
+            image: bitnamilegacy/nginx
             args:
             - /bin/sh
             - -c

--- a/source/documentation/other-topics/Setup-postgres-container.html.md.erb
+++ b/source/documentation/other-topics/Setup-postgres-container.html.md.erb
@@ -43,7 +43,7 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 Then install the edited chart like this:
 
 ```bash
-helm install mydb bitnami/postgresql -f values.yaml --namespace <your namespace>
+helm install mydb bitnamilegacy/postgresql -f values.yaml --namespace <your namespace>
 ```
 
 Change `mydb` to whatever name you want your pod to have.

--- a/source/documentation/other-topics/apiversion-changes-cronjob-k8s-1-25.html.md.erb
+++ b/source/documentation/other-topics/apiversion-changes-cronjob-k8s-1-25.html.md.erb
@@ -53,7 +53,7 @@ spec:
         spec:
           containers:
           - name: hello
-            image: bitnami/nginx
+            image: bitnamilegacy/nginx
             args:
             - /bin/sh
             - -c

--- a/source/documentation/other-topics/aws-rds-migration.html.md.erb
+++ b/source/documentation/other-topics/aws-rds-migration.html.md.erb
@@ -51,7 +51,7 @@ With that deconstructed process, it is easier to debug issues (and get help from
 In order to run postgresql commands against both of those endpoints, you need access to both.
 
 This is solved by launching a pod on the live1 kubernetes cluster, in the team's namespace.
-The migration steps outlined below have been tested from a pod running the `bitnami/postgresql` Docker image.
+The migration steps outlined below have been tested from a pod running the `bitnamilegacy/postgresql` Docker image.
 
 Network access requirements:
 

--- a/source/documentation/other-topics/statefulsets.html.md.erb
+++ b/source/documentation/other-topics/statefulsets.html.md.erb
@@ -73,7 +73,7 @@ spec:
     spec:
       containers: # Container images with their corresponding settings
       - name: nginx
-        image: bitnami/nginx:latest
+        image: bitnamilegacy/nginx:latest
         ports:
         - containerPort: 8080
           name: web


### PR DESCRIPTION
Updated Bitnami references to legacy as part of the migration plan.

See: https://github.com/orgs/ministryofjustice/projects/65?pane=issue&itemId=120717229&issue=ministryofjustice%7Ccloud-platform%7C7379 