### PR TITLE
Add storage size prerequisite to RDS snapshot restore (Scenario B)

### DIFF
--- a/source/documentation/other-topics/rds-snapshots.html.md.erb
+++ b/source/documentation/other-topics/rds-snapshots.html.md.erb
@@ -135,20 +135,20 @@ Use this when restoring a snapshot to a completely different database instance.
 
 #### Prerequisites
 
-> **Important:** The `db_allocated_storage` for the target database must be **at least equal to** the source database's allocated storage. RDS does not allow you to restore a snapshot into an instance with less storage than the original. If you set a smaller value, the apply will fail with:
->
-> ```
-> InvalidParameterCombination: Invalid storage size for engine name postgres and storage type gp3: <size>
-> ```
->
-> Check the source database's allocated storage before configuring the target, either via the AWS CLI or the AWS Console:
->
-> ```bash
-> aws rds describe-db-instances \
->   --db-instance-identifier <source-rds-name> \
->   --query 'DBInstances[0].AllocatedStorage' \
->   --region eu-west-2
-> ```
+**Important:** The `db_allocated_storage` for the target database must be **at least equal to** the source database's allocated storage. RDS does not allow you to restore a snapshot into an instance with less storage than the original. If you set a smaller value, the apply will fail with:
+
+```
+InvalidParameterCombination: Invalid storage size for engine name postgres and storage type gp3: <size>
+```
+
+Check the source database's allocated storage before configuring the target, either via the AWS CLI or the AWS Console:
+
+```bash
+aws rds describe-db-instances \
+  --db-instance-identifier <source-rds-name> \
+  --query 'DBInstances[0].AllocatedStorage' \
+  --region eu-west-2
+```
 
 #### 1. Get SOURCE DB credentials
 

--- a/source/documentation/other-topics/rds-snapshots.html.md.erb
+++ b/source/documentation/other-topics/rds-snapshots.html.md.erb
@@ -133,6 +133,23 @@ Use this when restoring a snapshot to a completely different database instance.
 
 > **Note**: These instructions are only relevant to databases being migrated within the same namespace.
 
+#### Prerequisites
+
+> **Important:** The `db_allocated_storage` for the target database must be **at least equal to** the source database's allocated storage. RDS does not allow you to restore a snapshot into an instance with less storage than the original. If you set a smaller value, the apply will fail with:
+>
+> ```
+> InvalidParameterCombination: Invalid storage size for engine name postgres and storage type gp3: <size>
+> ```
+>
+> Check the source database's allocated storage before configuring the target, either via the AWS CLI or the AWS Console:
+>
+> ```bash
+> aws rds describe-db-instances \
+>   --db-instance-identifier <source-rds-name> \
+>   --query 'DBInstances[0].AllocatedStorage' \
+>   --region eu-west-2
+> ```
+
 #### 1. Get SOURCE DB credentials
 
 You need the source DB credentials for verification later.


### PR DESCRIPTION
## What

Adds a Prerequisites section to Scenario B (Restore to NEW Database) in the RDS snapshots documentation.

## Why

A user encountered this error during a snapshot restore migration:

```
InvalidParameterCombination: Invalid storage size for engine name postgres and storage type gp3: 20
```

Their source database had 50 GiB allocated storage, but the target defaulted to 20 GiB. RDS does not allow restoring a snapshot into an instance with less storage than the original.

## Changes

- Adds a Prerequisites section before Step 1 warning users to check and match the source DB's allocated storage
- Includes the error message they'll encounter if misconfigured
- Provides an AWS CLI command to check the source storage size