### PR TITLE
Update quick-reference.html.md.erb

### DIFF
--- a/source/documentation/other-topics/quick-reference.html.md.erb
+++ b/source/documentation/other-topics/quick-reference.html.md.erb
@@ -52,7 +52,7 @@ $ kubectl -n <namespace> get events
 You can get a shell inside a running container:
 
 ```
-$ kubectl -n <namespace> exec -it <pod> sh
+$ kubectl -n <namespace> exec -it <pod> -- sh
 ```
 
 For more information, click [here](https://kubernetes.io/docs/tasks/debug/debug-application/get-shell-running-container/)


### PR DESCRIPTION
Old syntax is not supported. `error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead`