### PR TITLE
Update service pod documentation with AWS CLI version link

### DIFF
--- a/source/documentation/other-topics/cloud-platform-service-pod.html.md.erb
+++ b/source/documentation/other-topics/cloud-platform-service-pod.html.md.erb
@@ -7,11 +7,9 @@ layout: google-analytics
 
 # <%= current_page.data.title %>
 
-The Cloud Platform team provide a "service pod" module to help users run maintenance tasks against namespace resources using the AWS CLI.
+The Cloud Platform team provide a "service pod" module to help users run maintenance tasks against namespace resources using the AWS CLI. You can see the [version of AWS CLI provided here](https://github.com/ministryofjustice/cloud-platform-terraform-service-pod#versions)
 
 You need to have complete step 1 (configuring IRSA) in [Accessing AWS APIs and resources from your namespace](/documentation/other-topics/accessing-aws-apis-and-resources-from-your-namespace.html#using-irsa-in-your-namespace) to use the service pod module.
-
-
 
 Once you've done that, you can create and use the service pod by completing the following three steps:
 


### PR DESCRIPTION
Added a link to the AWS CLI version in the service pod documentation.