### PR TITLE
docs: Route 53 domains must not contain personal names

### DIFF
--- a/source/documentation/other-topics/route53-zone.html.md.erb
+++ b/source/documentation/other-topics/route53-zone.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Creating a Route 53 Hosted Zone
-last_reviewed_on: 2025-04-17
+last_reviewed_on: 2026-09-03
 review_in: 6 months
 layout: google-analytics
 ---
@@ -53,6 +53,8 @@ provider "aws" {
 This file declares the variables fields utilised in the route53.tf file below
 
 Fill in the variables below with your settings. Fill _namespace_ field below with your existing kubernetes namespace, all the _example_ fields below with desired values (all lowercase, and no spaces), and the _domain_ variable with your desired URL (pay special attention if your URL contains "justice" or not).
+
+> Note: Domain names must not contain personal names. For example, `john-smith.service.justice.gov.uk` is not allowed. Name the domain after your application, service or team instead.
 
 ```
 variable "namespace" {


### PR DESCRIPTION
## What

Adds a note to the guide stating that **domain names must not contain personal names**.

## Why

Domains containing personal names are not allowed at the MoJ. This was not previously documented, so teams creating hosted zones had no way of knowing the rule before raising a PR.

## Where

The note is placed at the point the `domain` variable is introduced (the `variables.tf` section), which is where a user chooses their domain name, with a brief example and guidance to name the domain after the application, service or team instead. 

Here's the [reference scenario](https://mojdt.slack.com/archives/C01BUKJSZD4/p1786361694507009?thread_ts=1786347891.432219&cid=C01BUKJSZD4)
